### PR TITLE
Remove Earthstar-style timestamp behaviour

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,6 @@
 {
   "tasks": {
+    "test": "deno test --unstable src",
     "bundle": "deno run --allow-all scripts/build_web_bundle.ts"
   },
   "lock": false,

--- a/src/replica/replica.test.ts
+++ b/src/replica/replica.test.ts
@@ -223,40 +223,7 @@ Deno.test("Replica.set", async (test) => {
 
     assert(res.kind === "success");
     assert(res.signed.entry.record.timestamp >= timestampBefore);
-    assert(res.signed.entry.record.timestamp < BigInt(Date.now() * 1000));
-  });
-
-  await test.step("If no timestamp is set, and there is something else at the same path with a higher timestamp than now, then the timestamp is that timestamp + 1", async () => {
-    const replica = new TestReplica();
-
-    const first = await replica.set(
-      namespaceKeypair,
-      {
-        publicKey: new Uint8Array([7, 8, 9, 10]),
-        privateKey: new Uint8Array([7, 8, 9, 10]),
-      },
-      {
-        path: new Uint8Array([1, 2, 3, 4]),
-        payload: new Uint8Array([2, 2, 2, 2]),
-        timestamp: BigInt((Date.now() + 10) * 1000),
-      },
-    );
-
-    const second = await replica.set(
-      namespaceKeypair,
-      authorKeypair,
-      {
-        path: new Uint8Array([1, 2, 3, 4]),
-        payload: new Uint8Array([1, 1, 1, 1]),
-      },
-    );
-
-    assert(first.kind === "success");
-    assert(second.kind === "success");
-    assertEquals(
-      second.signed.entry.record.timestamp,
-      first.signed.entry.record.timestamp + BigInt(1),
-    );
+    assert(res.signed.entry.record.timestamp <= BigInt(Date.now() * 1000));
   });
 
   // if a timestamp is set,
@@ -439,6 +406,7 @@ Deno.test("Replica.ingestEntry", async (test) => {
       {
         path: new Uint8Array([0, 0, 0, 0]),
         payload: new Uint8Array([0, 1, 2, 1]),
+        timestamp: BigInt(1000),
       },
     );
 
@@ -448,6 +416,7 @@ Deno.test("Replica.ingestEntry", async (test) => {
       {
         path: new Uint8Array([0, 0, 0, 0]),
         payload: new Uint8Array([0, 1, 2, 3]),
+        timestamp: BigInt(2000),
       },
     );
 

--- a/src/replica/replica.ts
+++ b/src/replica/replica.ts
@@ -182,37 +182,9 @@ export class Replica<KeypairType> extends EventTarget {
       path: input.path,
     };
 
-    let timestamp = input.timestamp !== undefined
+    const timestamp = input.timestamp !== undefined
       ? input.timestamp
       : BigInt(Date.now() * 1000);
-
-    if (!input.timestamp) {
-      // Get the latest timestamp from the same path and plus one.
-
-      for await (
-        const [signed] of this.query({
-          order: "path",
-          lowerBound: input.path,
-          upperBound: incrementLastByte(input.path),
-        })
-      ) {
-        //
-        if (
-          compareBytes(
-            signed.entry.identifier.path,
-            input.path,
-          ) !== 0
-        ) {
-          break;
-        }
-
-        const proposedTimestamp = signed.entry.record.timestamp + BigInt(1);
-
-        if (proposedTimestamp > timestamp) {
-          timestamp = proposedTimestamp;
-        }
-      }
-    }
 
     // Stage it with the driver
     const stagedResult = await this.payloadDriver.stage(input.payload);


### PR DESCRIPTION
In Earthstar and Willow, it is possible to create a document / entry without specifying a timestamp.

In Earthstar, the timestamp would be the current time _or_ the timestamp of the latest document at that path (regardless of author) + 1, whichever is greater.

I added this behaviour to Willow but am now removing it after discussing it with @AljoschaMeyer. Earthstar can still add on this behaviour later if we want that.

