### PR TITLE
Add a max path length parameter

### DIFF
--- a/src/replica/replica.test.ts
+++ b/src/replica/replica.test.ts
@@ -116,6 +116,7 @@ class TestReplica extends Replica<
           encodedLength() {
             return 1;
           },
+          maxLength: 8,
         },
         payloadScheme: {
           encode(hash) {

--- a/src/replica/types.ts
+++ b/src/replica/types.ts
@@ -9,12 +9,9 @@ export interface ProtocolParameters<
   AuthorisationOpts,
   AuthorisationToken,
 > {
-  // The path encoding scheme.
-  /** The encoding scheme used for paths.
-   *
-   * An encoded path **must** be the concatenation of a big-endian k-bit integer (where k is the number of bits needed to represent all numbers from 0 to your max path length, inclusive) and the bytes of the paths themselves.
-   */
-  pathLengthEncoding: EncodingScheme<number>;
+  pathLengthEncoding: EncodingScheme<number> & {
+    maxLength: number;
+  };
 
   // Namespace encoding scheme
   namespaceScheme: EncodingScheme<NamespacePublicKey> & {

--- a/src/replica/util.ts
+++ b/src/replica/util.ts
@@ -218,3 +218,50 @@ export function decodeSummarisableStorageValue<PayloadDigest>(
     authTokenHash,
   };
 }
+
+// The successor of a path depends on the maximum length a path can have.
+// Once a path reaches the maximum length, the bytestring is incremented to the left,
+// e.g. [0, 0, 0, 255] -> [0, 0, 1, 255].
+export function makeSuccessorPath(
+  maxLength: number,
+): (bytes: Uint8Array) => Uint8Array {
+  return (bytes: Uint8Array) => {
+    if (bytes.byteLength < maxLength) {
+      const newBytes = new Uint8Array(bytes.byteLength + 1);
+
+      newBytes.set(bytes, 0);
+      newBytes.set([0], bytes.byteLength);
+
+      return newBytes;
+    } else {
+      return incrementBytesLeft(bytes);
+    }
+  };
+}
+
+function incrementBytesLeft(bytes: Uint8Array): Uint8Array {
+  const newBytes = new Uint8Array(bytes.byteLength);
+
+  const last = bytes[bytes.byteLength - 1];
+
+  if (last === 255 && bytes.byteLength > 1) {
+    newBytes.set([last + 1], bytes.byteLength - 1);
+
+    const left = incrementBytesLeft(bytes.slice(0, bytes.byteLength - 1));
+
+    if (last === 255 && left[left.byteLength - 1] === 255) {
+      return bytes;
+    }
+
+    newBytes.set(left, 0);
+
+    return newBytes;
+  } else if (last === 255) {
+    return bytes;
+  } else {
+    newBytes.set([last + 1], bytes.byteLength - 1);
+    newBytes.set(bytes.slice(0, bytes.byteLength - 1), 0);
+
+    return newBytes;
+  }
+}


### PR DESCRIPTION
This is internally used when making the upper bound for certain queries. Without it, some entries would be incorrectly excluded in certain contexts.