### PR TITLE
Storage3d abstraction, 3d fingerprints and queries.

### DIFF
--- a/debug/replica.ts
+++ b/debug/replica.ts
@@ -103,7 +103,7 @@ const protocolParameters: ProtocolParameters<
           decode: (v) => v,
           encodedLength: (v) => v.byteLength,
         },
-        pathEncoding: {
+        pathLengthScheme: {
           encode(path) {
             const bytes = new Uint8Array(1 + path.byteLength);
             bytes[0] = path.byteLength;
@@ -119,7 +119,7 @@ const protocolParameters: ProtocolParameters<
             return 1 + path.byteLength;
           },
         },
-        payloadDigestEncoding: {
+        payloadScheme: {
           encode(hash) {
             return new Uint8Array(hash);
           },
@@ -157,7 +157,7 @@ const protocolParameters: ProtocolParameters<
           decode: (v) => v,
           encodedLength: (v) => v.byteLength,
         },
-        pathEncoding: {
+        pathLengthScheme: {
           encode(path) {
             const bytes = new Uint8Array(1 + path.byteLength);
             bytes[0] = path.byteLength;
@@ -173,7 +173,7 @@ const protocolParameters: ProtocolParameters<
             return 1 + path.byteLength;
           },
         },
-        payloadDigestEncoding: {
+        payloadScheme: {
           encode(hash) {
             return new Uint8Array(hash);
           },

--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,4 @@
 {
-  "imports": {
-    "$std/": "https://deno.land/std@0.203.0/",
-    "$meadowcap/": "../meadowcap/"
-  },
   "tasks": {
     "test": "deno test --unstable src",
     "bundle": "deno run --allow-all scripts/build_web_bundle.ts"

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,7 @@
+export * as Products from "https://deno.land/x/willow_3d_products@0.1.0/mod.ts";
+export { deferred } from "https://deno.land/std@0.202.0/async/deferred.ts";
+export { concat } from "https://deno.land/std@0.202.0/bytes/concat.ts";
+export { equals as equalsBytes } from "https://deno.land/std@0.202.0/bytes/equals.ts";
+export { encode as encodeBase32 } from "https://deno.land/std@0.202.0/encoding/base32.ts";
+export { encode as encodeBase64 } from "https://deno.land/std@0.202.0/encoding/base64.ts";
+export { toArrayBuffer } from "https://deno.land/std@0.202.0/streams/to_array_buffer.ts";

--- a/mod.universal.ts
+++ b/mod.universal.ts
@@ -1,6 +1,5 @@
 export * from "./src/entries/types.ts";
 export * from "./src/entries/encode_decode.ts";
-export * from "./src/entries/sign_verify.ts";
 
 export * from "./src/replica/types.ts";
 export * from "./src/replica/replica.ts";

--- a/src/replica/replica.test.ts
+++ b/src/replica/replica.test.ts
@@ -5,126 +5,16 @@ import {
 import { compareBytes } from "../util/bytes.ts";
 import { Replica } from "./replica.ts";
 import { crypto } from "https://deno.land/std@0.188.0/crypto/crypto.ts";
-import { encodeEntry } from "../entries/encode_decode.ts";
 import { encodeEntryKeys, encodeSummarisableStorageValue } from "./util.ts";
-import { equalsBytes, Products } from "../../deps.ts";
 import {
-  FingerprintScheme,
-  NamespaceScheme,
-  PathLengthScheme,
-  PayloadScheme,
-  SubspaceScheme,
-} from "./types.ts";
-
-async function makeKeypair() {
-  const { publicKey, privateKey } = await crypto.subtle.generateKey(
-    {
-      name: "ECDSA",
-      namedCurve: "P-256",
-    },
-    true,
-    ["sign", "verify"],
-  );
-
-  return {
-    subspace: new Uint8Array(
-      await window.crypto.subtle.exportKey("raw", publicKey),
-    ),
-    privateKey,
-  };
-}
-
-function importPublicKey(raw: ArrayBuffer) {
-  return crypto.subtle.importKey(
-    "raw",
-    raw,
-    {
-      name: "ECDSA",
-      namedCurve: "P-256",
-    },
-    true,
-    ["verify"],
-  );
-}
-
-const testSchemeNamespace: NamespaceScheme<Uint8Array> = {
-  encode: (v) => v,
-  decode: (v) => v,
-  encodedLength: (v) => v.byteLength,
-  isEqual: equalsBytes,
-};
-
-const testSchemeSubspace: SubspaceScheme<Uint8Array> = {
-  encode: (v) => v,
-  decode: (v) => v.subarray(0, 65),
-  encodedLength: () => 65,
-  isEqual: equalsBytes,
-  minimalSubspaceKey: new Uint8Array(65),
-  order: Products.orderPaths,
-  successor: Products.makeSuccessorPath(65),
-};
-
-const testSchemePathLength: PathLengthScheme = {
-  encode(length) {
-    return new Uint8Array([length]);
-  },
-  decode(bytes) {
-    return bytes[0];
-  },
-  encodedLength() {
-    return 1;
-  },
-  maxLength: 8,
-};
-
-const testSchemePayload: PayloadScheme<ArrayBuffer> = {
-  encode(hash) {
-    return new Uint8Array(hash);
-  },
-  decode(bytes) {
-    return bytes.subarray(0, 32);
-  },
-  encodedLength() {
-    return 32;
-  },
-  async fromBytes(bytes) {
-    return new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
-  },
-  order(a, b) {
-    return compareBytes(new Uint8Array(a), new Uint8Array(b)) as
-      | 1
-      | 0
-      | -1;
-  },
-};
-
-const testSchemeFingerprint: FingerprintScheme<
-  Uint8Array,
-  Uint8Array,
-  Uint8Array,
-  Uint8Array
-> = {
-  neutral: new Uint8Array(32),
-  async fingerprintSingleton(entry) {
-    const encodedEntry = encodeEntry(entry, {
-      namespaceScheme: testSchemeNamespace,
-      subspaceScheme: testSchemeSubspace,
-      pathLengthScheme: testSchemePathLength,
-      payloadScheme: testSchemePayload,
-    });
-
-    return new Uint8Array(await crypto.subtle.digest("SHA-256", encodedEntry));
-  },
-  fingerprintCombine(a, b) {
-    const bytes = new Uint8Array(32);
-
-    for (let i = 0; i < 32; i++) {
-      bytes.set([a[i] ^ b[i]], i);
-    }
-
-    return bytes;
-  },
-};
+  testSchemeAuthorisation,
+  testSchemeFingerprint,
+  testSchemeNamespace,
+  testSchemePathLength,
+  testSchemePayload,
+  testSchemeSubspace,
+} from "../test/test_schemes.ts";
+import { makeSubspaceKeypair } from "../test/crypto.ts";
 
 class TestReplica extends Replica<
   Uint8Array,
@@ -142,52 +32,7 @@ class TestReplica extends Replica<
         subspaceScheme: testSchemeSubspace,
         pathLengthScheme: testSchemePathLength,
         payloadScheme: testSchemePayload,
-        authorisationScheme: {
-          async authorise(entry, secretKey) {
-            const encodedEntry = encodeEntry(entry, {
-              namespaceScheme: testSchemeNamespace,
-              subspaceScheme: testSchemeSubspace,
-              pathLengthScheme: testSchemePathLength,
-              payloadScheme: testSchemePayload,
-            });
-
-            const res = await crypto.subtle.sign(
-              {
-                name: "ECDSA",
-                hash: { name: "SHA-256" },
-              },
-              secretKey,
-              encodedEntry,
-            );
-
-            return new Uint8Array(res);
-          },
-          async isAuthorised(entry, token) {
-            const cryptoKey = await importPublicKey(entry.identifier.subspace);
-
-            const encodedEntry = encodeEntry(entry, {
-              namespaceScheme: testSchemeNamespace,
-              subspaceScheme: testSchemeSubspace,
-              pathLengthScheme: testSchemePathLength,
-              payloadScheme: testSchemePayload,
-            });
-
-            return crypto.subtle.verify(
-              {
-                name: "ECDSA",
-                hash: { name: "SHA-256" },
-              },
-              cryptoKey,
-              token,
-              encodedEntry,
-            );
-          },
-          tokenEncoding: {
-            encode: (ab) => new Uint8Array(ab),
-            decode: (bytes) => bytes.buffer,
-            encodedLength: (ab) => ab.byteLength,
-          },
-        },
+        authorisationScheme: testSchemeAuthorisation,
         fingerprintScheme: testSchemeFingerprint,
       },
     });
@@ -210,8 +55,8 @@ class TestReplica extends Replica<
 // Namespace length must equal protocol parameter pub key length
 
 Deno.test("Replica.set", async (test) => {
-  const authorKeypair = await makeKeypair();
-  const author2Keypair = await makeKeypair();
+  const authorKeypair = await makeSubspaceKeypair();
+  const author2Keypair = await makeSubspaceKeypair();
 
   await test.step("Fails with invalid ingestions", async () => {
     const replica = new TestReplica();
@@ -305,8 +150,8 @@ Deno.test("Replica.set", async (test) => {
 // ingestEntry
 
 Deno.test("Replica.ingestEntry", async (test) => {
-  const authorKeypair = await makeKeypair();
-  const author2Keypair = await makeKeypair();
+  const authorKeypair = await makeSubspaceKeypair();
+  const author2Keypair = await makeSubspaceKeypair();
 
   // rejects stuff from a different namespace
   await test.step("Rejects entries from a different namespace", async () => {
@@ -586,7 +431,7 @@ Deno.test("Replica.ingestEntry", async (test) => {
 // ingestPayload
 
 Deno.test("Replica.ingestPayload", async (test) => {
-  const authorKeypair = await makeKeypair();
+  const authorKeypair = await makeSubspaceKeypair();
 
   await test.step("does not ingest payload if corresponding entry is missing", async () => {
     const replica = new TestReplica();
@@ -715,7 +560,7 @@ Deno.test("Replica.ingestPayload", async (test) => {
 // WAF
 
 Deno.test("Write-ahead flags", async (test) => {
-  const authorKeypair = await makeKeypair();
+  const authorKeypair = await makeSubspaceKeypair();
 
   await test.step("Insertion flag inserts (and removes prefixes...)", async () => {
     const replica = new TestReplica();

--- a/src/replica/replica.ts
+++ b/src/replica/replica.ts
@@ -1,10 +1,6 @@
 import { EntryDriverMemory } from "./storage/entry_drivers/memory.ts";
 import { EntryDriver, PayloadDriver } from "./storage/types.ts";
-import {
-  bigintToBytes,
-  compareBytes,
-  incrementLastByte,
-} from "../util/bytes.ts";
+import { bigintToBytes, compareBytes } from "../util/bytes.ts";
 import {
   EntryInput,
   IngestEvent,
@@ -15,7 +11,6 @@ import {
   ReplicaOpts,
 } from "./types.ts";
 import { PayloadDriverMemory } from "./storage/payload_drivers/memory.ts";
-import { SummarisableStorage } from "./storage/summarisable_storage/types.ts";
 import { Entry } from "../entries/types.ts";
 import {
   EntryIngestEvent,
@@ -23,16 +18,8 @@ import {
   EntryRemoveEvent,
   PayloadIngestEvent,
 } from "./events.ts";
-import { deferred } from "$std/async/deferred.ts";
-import { concat } from "$std/bytes/concat.ts";
-import { equals as equalsBytes } from "$std/bytes/equals.ts";
-import {
-  decodeEntryKey,
-  decodeSummarisableStorageValue,
-  encodeEntryKeys,
-  encodeSummarisableStorageValue,
-  makeSuccessorPath,
-} from "./util.ts";
+import { concat, deferred, Products } from "../../deps.ts";
+import { Storage3d } from "./storage/storage_3d/types.ts";
 
 /** A local snapshot of a namespace to be written to, queried from, and synced with other replicas.
  *
@@ -46,6 +33,7 @@ export class Replica<
   PayloadDigest,
   AuthorisationOpts,
   AuthorisationToken,
+  Fingerprint,
 > extends EventTarget {
   namespace: NamespacePublicKey;
 
@@ -54,17 +42,24 @@ export class Replica<
     SubspacePublicKey,
     PayloadDigest,
     AuthorisationOpts,
-    AuthorisationToken
+    AuthorisationToken,
+    Fingerprint
   >;
 
-  private ptsStorage: SummarisableStorage<Uint8Array, Uint8Array>;
-  private sptStorage: SummarisableStorage<Uint8Array, Uint8Array>;
-  private tspStorage: SummarisableStorage<Uint8Array, Uint8Array>;
-
-  private entryDriver: EntryDriver;
+  private entryDriver: EntryDriver<
+    NamespacePublicKey,
+    SubspacePublicKey,
+    PayloadDigest,
+    Fingerprint
+  >;
   private payloadDriver: PayloadDriver<PayloadDigest>;
 
-  private incrementPath: (path: Uint8Array) => Uint8Array;
+  private storage: Storage3d<
+    NamespacePublicKey,
+    SubspacePublicKey,
+    PayloadDigest,
+    Fingerprint
+  >;
 
   private checkedWriteAheadFlag = deferred();
 
@@ -74,7 +69,8 @@ export class Replica<
       SubspacePublicKey,
       PayloadDigest,
       AuthorisationOpts,
-      AuthorisationToken
+      AuthorisationToken,
+      Fingerprint
     >,
   ) {
     super();
@@ -82,20 +78,20 @@ export class Replica<
     this.namespace = opts.namespace;
     this.protocolParams = opts.protocolParameters;
 
-    const entryDriver = opts.entryDriver || new EntryDriverMemory();
+    const entryDriver = opts.entryDriver || new EntryDriverMemory({
+      pathLengthScheme: opts.protocolParameters.pathLengthScheme,
+      payloadScheme: opts.protocolParameters.payloadScheme,
+      subspaceScheme: opts.protocolParameters.subspaceScheme,
+      fingerprintScheme: opts.protocolParameters.fingerprintScheme,
+    });
     const payloadDriver = opts.payloadDriver ||
       new PayloadDriverMemory(opts.protocolParameters.payloadScheme);
 
     this.entryDriver = entryDriver;
+
+    this.storage = entryDriver.makeStorage(this.namespace);
+
     this.payloadDriver = payloadDriver;
-
-    this.ptsStorage = entryDriver.createSummarisableStorage("pts");
-    this.sptStorage = entryDriver.createSummarisableStorage("spt");
-    this.tspStorage = entryDriver.createSummarisableStorage("tsp");
-
-    this.incrementPath = makeSuccessorPath(
-      this.protocolParams.pathLengthEncoding.maxLength,
-    );
 
     this.checkWriteAheadFlag();
   }
@@ -105,40 +101,9 @@ export class Replica<
     const existingRemove = await this.entryDriver.writeAheadFlag.wasRemoving();
 
     if (existingInsert) {
-      const ptsKey = existingInsert[0];
-
-      const values = decodeSummarisableStorageValue(
-        existingInsert[1],
-        this.protocolParams.payloadScheme,
-        this.protocolParams.pathLengthEncoding,
-      );
-
-      const details = decodeEntryKey(
-        ptsKey,
-        "path",
-        this.protocolParams.subspaceScheme,
-        values.pathLength,
-      );
-
-      const keys = encodeEntryKeys(
-        {
-          path: details.path,
-          timestamp: details.timestamp,
-          subspace: details.subspace,
-          subspaceEncoding: this.protocolParams.subspaceScheme,
-        },
-      );
-
-      // Remove key for each storage.
-      await Promise.all([
-        this.ptsStorage.remove(keys.pts),
-        this.tspStorage.remove(keys.tsp),
-        this.sptStorage.remove(keys.spt),
-      ]);
-
       // TODO(AUTH): Get the encoded authtoken out of payload driver.
       const encodedAuthToken = await this.payloadDriver.get(
-        values.authTokenHash,
+        existingInsert.authTokenHash,
       );
 
       if (encodedAuthToken) {
@@ -146,55 +111,20 @@ export class Replica<
           .tokenEncoding.decode(await encodedAuthToken?.bytes());
 
         await this.insertEntry({
-          path: details.path,
-          subspace: details.subspace,
-          hash: values.payloadHash,
-          length: values.payloadLength,
-          timestamp: details.timestamp,
+          path: existingInsert.entry.identifier.path,
+          subspace: existingInsert.entry.identifier.subspace,
+          hash: existingInsert.entry.record.hash,
+          length: existingInsert.entry.record.length,
+          timestamp: existingInsert.entry.record.timestamp,
           authToken: decodedToken,
         });
       }
+
+      await this.entryDriver.writeAheadFlag.unflagInsertion();
     }
 
     if (existingRemove) {
-      const entryValues = await this.ptsStorage.get(existingRemove);
-
-      if (!entryValues) {
-        await this.entryDriver.writeAheadFlag.unflagRemoval();
-
-        return;
-      }
-
-      const { pathLength } = decodeSummarisableStorageValue(
-        entryValues,
-        this.protocolParams.payloadScheme,
-        this.protocolParams.pathLengthEncoding,
-      );
-
-      // Derive TAP, APT keys from PTA.
-      const ptsKey = existingRemove;
-
-      const details = decodeEntryKey(
-        ptsKey,
-        "path",
-        this.protocolParams.subspaceScheme,
-        pathLength,
-      );
-      const keys = encodeEntryKeys(
-        {
-          path: details.path,
-          timestamp: details.timestamp,
-          subspace: details.subspace,
-          subspaceEncoding: this.protocolParams.subspaceScheme,
-        },
-      );
-
-      // Remove key for each storage.
-      await Promise.all([
-        this.ptsStorage.remove(keys.pts),
-        this.tspStorage.remove(keys.tsp),
-        this.sptStorage.remove(keys.spt),
-      ]);
+      await this.storage.remove(existingRemove);
 
       // Unflag remove
       await this.entryDriver.writeAheadFlag.unflagRemoval();
@@ -302,13 +232,6 @@ export class Replica<
       };
     }
 
-    // Check for entries at the same path from the same author.
-    const entryAuthorPathKey = concat(
-      this.protocolParams.subspaceScheme.encode(entry.identifier.subspace),
-      entry.identifier.path,
-    );
-    const entryAuthorPathKeyUpper = this.incrementPath(entryAuthorPathKey);
-
     const prefixKey = concat(
       this.protocolParams.subspaceScheme.encode(entry.identifier.subspace),
       entry.identifier.path,
@@ -330,47 +253,38 @@ export class Replica<
       }
     }
 
+    // Check for collisions with stored entries
+
     for await (
-      const otherEntry of this.sptStorage.entries(
-        entryAuthorPathKey,
-        entryAuthorPathKeyUpper,
+      const { entry: otherEntry } of this.storage.entriesByQuery(
+        {
+          order: "subspace",
+          subspace: {
+            lowerBound: entry.identifier.subspace,
+            upperBound: this.protocolParams.subspaceScheme.successor(
+              entry.identifier.subspace,
+            ),
+          },
+          path: {
+            lowerBound: entry.identifier.path,
+            upperBound: Products.makeSuccessorPath(
+              this.protocolParams.pathLengthScheme.maxLength,
+            )(entry.identifier.path),
+          },
+        },
       )
     ) {
-      // The new entry will overwrite the one we just found.
-      // Remove it.
-      const { pathLength: otherPathLength, payloadHash: otherPayloadHash } =
-        decodeSummarisableStorageValue(
-          otherEntry.value,
-          this.protocolParams.payloadScheme,
-          this.protocolParams.pathLengthEncoding,
-        );
-
-      const otherDetails = decodeEntryKey(
-        otherEntry.key,
-        "subspace",
-        this.protocolParams.subspaceScheme,
-        otherPathLength,
-      );
-
       if (
         compareBytes(
           entry.identifier.path,
-          otherDetails.path,
+          otherEntry.identifier.path,
         ) !== 0
       ) {
         break;
       }
 
-      const otherEntryTimestampBytesView = new DataView(
-        otherEntry.key.buffer,
-      );
-
-      const otherEntryTimestamp = otherEntryTimestampBytesView.getBigUint64(
-        otherEntry.key.byteLength - 8,
-      );
-
       //  If there is something existing and the timestamp is greater than ours, we have a no-op.
-      if (otherEntryTimestamp > entry.record.timestamp) {
+      if (otherEntry.record.timestamp > entry.record.timestamp) {
         return {
           kind: "no_op",
           reason: "obsolete_from_same_subspace",
@@ -379,12 +293,12 @@ export class Replica<
 
       const payloadDigestOrder = this.protocolParams.payloadScheme.order(
         entry.record.hash,
-        otherPayloadHash,
+        otherEntry.record.hash,
       );
 
       // If the timestamps are the same, and our hash is less, we have a no-op.
       if (
-        otherEntryTimestamp === entry.record.timestamp &&
+        otherEntry.record.timestamp === entry.record.timestamp &&
         payloadDigestOrder === -1
       ) {
         return {
@@ -394,11 +308,11 @@ export class Replica<
       }
 
       const otherPayloadLengthIsGreater =
-        entry.record.length < otherEntryTimestamp;
+        entry.record.length < otherEntry.record.timestamp;
 
       // If the timestamps and hashes are the same, and the other payload's length is greater, we have a no-op.
       if (
-        otherEntryTimestamp === entry.record.timestamp &&
+        otherEntry.record.timestamp === entry.record.timestamp &&
         payloadDigestOrder === 0 && otherPayloadLengthIsGreater
       ) {
         return {
@@ -407,24 +321,13 @@ export class Replica<
         };
       }
 
-      const otherKeys = encodeEntryKeys(
-        {
-          path: otherDetails.path,
-          timestamp: otherDetails.timestamp,
-          subspace: otherDetails.subspace,
-          subspaceEncoding: this.protocolParams.subspaceScheme,
-        },
-      );
-
-      await Promise.all([
-        this.ptsStorage.remove(otherKeys.pts),
-        this.tspStorage.remove(otherKeys.tsp),
-        this.sptStorage.remove(otherKeys.spt),
-      ]);
+      await this.storage.remove(otherEntry);
 
       const toRemovePrefixKey = concat(
-        this.protocolParams.subspaceScheme.encode(otherDetails.subspace),
-        otherDetails.path,
+        this.protocolParams.subspaceScheme.encode(
+          otherEntry.identifier.subspace,
+        ),
+        otherEntry.identifier.path,
       );
 
       await this.entryDriver.prefixIterator.remove(
@@ -472,32 +375,23 @@ export class Replica<
       authToken: AuthorisationToken;
     },
   ) {
-    const keys = encodeEntryKeys(
-      {
-        path,
-        timestamp,
-        subspace,
-        subspaceEncoding: this.protocolParams.subspaceScheme,
-      },
-    );
-
     const encodedToken = this.protocolParams.authorisationScheme
       .tokenEncoding.encode(authToken);
 
     const stagingResult = await this.payloadDriver.stage(encodedToken);
 
-    const toStore = encodeSummarisableStorageValue(
-      {
-        payloadHash: hash,
-        payloadLength: length,
-        authTokenHash: stagingResult.hash,
-        payloadEncoding: this.protocolParams.payloadScheme,
-        pathLength: path.byteLength,
-        pathLengthEncoding: this.protocolParams.pathLengthEncoding,
+    await this.entryDriver.writeAheadFlag.flagInsertion({
+      identifier: {
+        namespace: this.namespace,
+        subspace: subspace,
+        path: path,
       },
-    );
-
-    await this.entryDriver.writeAheadFlag.flagInsertion(keys.pts, toStore);
+      record: {
+        hash,
+        length,
+        timestamp,
+      },
+    }, stagingResult.hash);
 
     const prefixKey = concat(
       this.protocolParams.subspaceScheme.encode(subspace),
@@ -505,20 +399,24 @@ export class Replica<
     );
 
     await Promise.all([
-      this.ptsStorage.insert(keys.pts, toStore),
-      this.sptStorage.insert(keys.spt, toStore),
-      this.tspStorage.insert(keys.tsp, toStore),
+      this.storage.insert({
+        payloadHash: hash,
+        authTokenHash: stagingResult.hash,
+        length,
+        path,
+        subspace,
+        timestamp,
+      }),
       stagingResult.commit(),
+      this.entryDriver.prefixIterator.insert(
+        prefixKey,
+        bigintToBytes(timestamp),
+      ),
     ]);
-
-    await this.entryDriver.prefixIterator.insert(
-      prefixKey,
-      keys.spt.subarray(keys.spt.byteLength - 8),
-    );
 
     // And remove all prefixes with smaller timestamps.
     for await (
-      const [prefixedByPath, prefixedByTimestamp] of this.entryDriver
+      const [prefixedByKey, prefixedByTimestamp] of this.entryDriver
         .prefixIterator
         .prefixedBy(
           prefixKey,
@@ -529,69 +427,35 @@ export class Replica<
 
       if (prefixTimestamp < timestamp) {
         const subspace = this.protocolParams.subspaceScheme.decode(
-          prefixedByPath,
+          prefixedByKey,
         );
 
         const encodedSubspaceLength = this.protocolParams.subspaceScheme
           .encodedLength(subspace);
 
-        const prefixedPath = prefixedByPath.subarray(
+        const prefixedPath = prefixedByKey.subarray(
           encodedSubspaceLength,
         );
 
-        // Delete.
-        // Flag a deletion.
-        const toDeleteKeys = encodeEntryKeys(
-          {
-            path: prefixedPath,
-            timestamp: prefixTimestamp,
-            subspace: subspace,
-            subspaceEncoding: this.protocolParams.subspaceScheme,
-          },
-        );
+        const toDeleteResult = await this.storage.get(subspace, prefixedPath);
 
-        const toDeleteValue = await this.ptsStorage.get(toDeleteKeys.pts);
+        if (toDeleteResult) {
+          await this.entryDriver.writeAheadFlag.flagRemoval(
+            toDeleteResult.entry,
+          );
 
-        const storageStuff = toDeleteValue
-          ? decodeSummarisableStorageValue(
-            toDeleteValue,
-            this.protocolParams.payloadScheme,
-            this.protocolParams.pathLengthEncoding,
-          )
-          : undefined;
+          await Promise.all([
+            this.storage.remove(toDeleteResult.entry),
+            this.payloadDriver.erase(toDeleteResult.entry.record.hash),
+            this.entryDriver.prefixIterator.remove(prefixedByKey),
+          ]);
 
-        await this.entryDriver.writeAheadFlag.flagRemoval(toDeleteKeys.pts);
+          await this.entryDriver.writeAheadFlag.unflagRemoval();
 
-        // Remove from all the summarisable storages...
-        await Promise.all([
-          this.ptsStorage.remove(toDeleteKeys.pts),
-          this.tspStorage.remove(toDeleteKeys.tsp),
-          this.sptStorage.remove(toDeleteKeys.spt),
-          this.entryDriver.prefixIterator.remove(prefixedByPath),
-          // Don't fail if we couldn't get the value of the hash due to DB being in a wonky state.
-          storageStuff
-            ? this.payloadDriver.erase(storageStuff.payloadHash)
-            : () => {},
-        ]);
-
-        if (storageStuff) {
           this.dispatchEvent(
-            new EntryRemoveEvent({
-              identifier: {
-                path: prefixedPath,
-                subspace,
-                namespace: this.namespace,
-              },
-              record: {
-                hash: storageStuff.payloadHash,
-                length: storageStuff.payloadLength,
-                timestamp: prefixTimestamp,
-              },
-            }),
+            new EntryRemoveEvent(toDeleteResult.entry),
           );
         }
-
-        await this.entryDriver.writeAheadFlag.unflagRemoval();
       }
     }
 
@@ -610,110 +474,53 @@ export class Replica<
     },
     payload: Uint8Array | ReadableStream<Uint8Array>,
   ): Promise<IngestPayloadEvent> {
-    // Check that there is an entry for this, and get the payload hash!
-    const encodedSubspace = this.protocolParams.subspaceScheme.encode(
+    const getResult = await this.storage.get(
       entryDetails.subspace,
+      entryDetails.path,
     );
 
-    const keyLength = 8 + encodedSubspace.byteLength +
-      entryDetails.path.byteLength;
-    const ptsBytes = new Uint8Array(keyLength);
-
-    ptsBytes.set(entryDetails.path, 0);
-    const ptsDv = new DataView(ptsBytes.buffer);
-    ptsDv.setBigUint64(
-      entryDetails.path.byteLength,
-      entryDetails.timestamp,
-    );
-    ptsBytes.set(encodedSubspace, entryDetails.path.byteLength + 8);
-
-    for await (
-      const kvEntry of this.ptsStorage.entries(
-        ptsBytes,
-        incrementLastByte(ptsBytes),
-        {
-          limit: 1,
-        },
-      )
-    ) {
-      if (!equalsBytes(kvEntry.key, ptsBytes)) {
-        break;
-      }
-
-      // Check if we already have it.
-      const {
-        payloadHash,
-        payloadLength,
-        pathLength,
-      } = decodeSummarisableStorageValue(
-        kvEntry.value,
-        this.protocolParams.payloadScheme,
-        this.protocolParams.pathLengthEncoding,
-      );
-
-      const existingPayload = await this.payloadDriver.get(payloadHash);
-
-      if (existingPayload) {
-        return {
-          kind: "no_op",
-          reason: "already_have_it",
-        };
-      }
-
-      const stagedResult = await this.payloadDriver.stage(payload);
-
-      if (
-        this.protocolParams.payloadScheme.order(
-          stagedResult.hash,
-          payloadHash,
-        ) !== 0
-      ) {
-        await stagedResult.reject();
-
-        return {
-          kind: "failure",
-          reason: "mismatched_hash",
-        };
-      }
-
-      const committedPayload = await stagedResult.commit();
-
-      const { subspace, path, timestamp } = decodeEntryKey(
-        kvEntry.key,
-        "path",
-        this.protocolParams.subspaceScheme,
-        pathLength,
-      );
-
-      const entry: Entry<
-        NamespacePublicKey,
-        SubspacePublicKey,
-        PayloadDigest
-      > = {
-        identifier: {
-          subspace,
-          namespace: this.namespace,
-          path,
-        },
-        record: {
-          hash: payloadHash,
-          length: payloadLength,
-          timestamp,
-        },
-      };
-
-      this.dispatchEvent(
-        new PayloadIngestEvent(entry, committedPayload),
-      );
-
+    if (!getResult) {
       return {
-        kind: "success",
+        kind: "failure",
+        reason: "no_entry",
       };
     }
 
+    const { entry } = getResult;
+
+    const existingPayload = await this.payloadDriver.get(entry.record.hash);
+
+    if (existingPayload) {
+      return {
+        kind: "no_op",
+        reason: "already_have_it",
+      };
+    }
+
+    const stagedResult = await this.payloadDriver.stage(payload);
+
+    if (
+      this.protocolParams.payloadScheme.order(
+        stagedResult.hash,
+        entry.record.hash,
+      ) !== 0
+    ) {
+      await stagedResult.reject();
+
+      return {
+        kind: "failure",
+        reason: "mismatched_hash",
+      };
+    }
+
+    const committedPayload = await stagedResult.commit();
+
+    this.dispatchEvent(
+      new PayloadIngestEvent(entry, committedPayload),
+    );
+
     return {
-      kind: "failure",
-      reason: "no_entry",
+      kind: "success",
     };
   }
 
@@ -727,78 +534,10 @@ export class Replica<
       AuthorisationToken,
     ]
   > {
-    let listToUse: SummarisableStorage<Uint8Array, Uint8Array>;
-    let lowerBound: Uint8Array | undefined;
-    let upperBound: Uint8Array | undefined;
-
-    switch (query.order) {
-      case "path":
-        lowerBound = query.lowerBound;
-        upperBound = query.upperBound;
-        listToUse = this.ptsStorage;
-        break;
-      case "subspace":
-        lowerBound = query.lowerBound
-          ? this.protocolParams.subspaceScheme.encode(query.lowerBound)
-          : undefined;
-        upperBound = query.upperBound
-          ? this.protocolParams.subspaceScheme.encode(query.upperBound)
-          : undefined;
-        listToUse = this.sptStorage;
-        break;
-      case "timestamp": {
-        if (query.lowerBound) {
-          lowerBound = bigintToBytes(query.lowerBound);
-        }
-
-        if (query.upperBound) {
-          upperBound = bigintToBytes(query.upperBound);
-        }
-
-        listToUse = this.tspStorage;
-        break;
-      }
-    }
-
-    const iterator = listToUse.entries(lowerBound, upperBound, {
-      reverse: query.reverse,
-      limit: query.limit,
-    });
-
-    for await (const kvEntry of iterator) {
-      const {
-        authTokenHash,
-        payloadHash,
-        payloadLength,
-        pathLength,
-      } = decodeSummarisableStorageValue(
-        kvEntry.value,
-        this.protocolParams.payloadScheme,
-        this.protocolParams.pathLengthEncoding,
-      );
-
-      const { subspace, path, timestamp } = decodeEntryKey(
-        kvEntry.key,
-        query.order,
-        this.protocolParams.subspaceScheme,
-        pathLength,
-      );
-
-      const entry: Entry<NamespacePublicKey, SubspacePublicKey, PayloadDigest> =
-        {
-          identifier: {
-            subspace,
-            namespace: this.namespace,
-            path,
-          },
-          record: {
-            hash: payloadHash,
-            length: payloadLength,
-            timestamp,
-          },
-        };
-
-      const payload = await this.payloadDriver.get(payloadHash);
+    for await (
+      const { entry, authTokenHash } of this.storage.entriesByQuery(query)
+    ) {
+      const payload = await this.payloadDriver.get(entry.record.hash);
 
       const authTokenPayload = await this.payloadDriver.get(authTokenHash);
 

--- a/src/replica/replica.ts
+++ b/src/replica/replica.ts
@@ -333,6 +333,10 @@ export class Replica<
       await this.entryDriver.prefixIterator.remove(
         toRemovePrefixKey,
       );
+
+      this.dispatchEvent(
+        new EntryRemoveEvent(otherEntry),
+      );
     }
 
     await this.insertEntry({

--- a/src/replica/storage/entry_drivers/kv_store.ts
+++ b/src/replica/storage/entry_drivers/kv_store.ts
@@ -1,62 +1,206 @@
+import { decodeEntry, encodeEntry } from "../../../entries/encode_decode.ts";
+import { Entry } from "../../../entries/types.ts";
 import { compareBytes } from "../../../util/bytes.ts";
-import { KvDriverDeno } from "../kv/kv_driver_deno.ts";
-import { PrefixedDriver } from "../kv/prefixed_driver.ts";
+import {
+  FingerprintScheme,
+  NamespaceScheme,
+  PathLengthScheme,
+  PayloadScheme,
+  SubspaceScheme,
+} from "../../types.ts";
 import { KvDriver } from "../kv/types.ts";
 import { KeyHopTree } from "../prefix_iterators/key_hop_tree.ts";
 import { PrefixIterator } from "../prefix_iterators/types.ts";
-import { sha256XorMonoid } from "../summarisable_storage/lifting_monoid.ts";
+import { TripleStorage } from "../storage_3d/triple_storage.ts";
+import { Storage3d } from "../storage_3d/types.ts";
+import { LiftingMonoid } from "../summarisable_storage/lifting_monoid.ts";
 import { Skiplist } from "../summarisable_storage/monoid_skiplist.ts";
-import { SummarisableStorage } from "../summarisable_storage/types.ts";
 import { EntryDriver } from "../types.ts";
 
+type EntryDriverKvOpts<
+  NamespaceKey,
+  SubspaceKey,
+  PayloadDigest,
+  Fingerprint,
+> = {
+  kvDriver: KvDriver;
+  namespaceScheme: NamespaceScheme<NamespaceKey>;
+  subspaceScheme: SubspaceScheme<SubspaceKey>;
+  payloadScheme: PayloadScheme<PayloadDigest>;
+  pathLengthScheme: PathLengthScheme;
+  fingerprintScheme: FingerprintScheme<
+    NamespaceKey,
+    SubspaceKey,
+    PayloadDigest,
+    Fingerprint
+  >;
+};
+
 /** Store and retrieve entries in a key-value store. */
-export class EntryDriverKvStore implements EntryDriver {
+export class EntryDriverKvStore<
+  NamespaceKey,
+  SubspaceKey,
+  PayloadDigest,
+  Fingerprint,
+> implements
+  EntryDriver<
+    NamespaceKey,
+    SubspaceKey,
+    PayloadDigest,
+    Fingerprint
+  > {
+  private namespaceScheme: NamespaceScheme<NamespaceKey>;
+  private subspaceScheme: SubspaceScheme<SubspaceKey>;
+  private payloadScheme: PayloadScheme<PayloadDigest>;
+  private pathLengthScheme: PathLengthScheme;
+  private fingerprintScheme: FingerprintScheme<
+    NamespaceKey,
+    SubspaceKey,
+    PayloadDigest,
+    Fingerprint
+  >;
+
   private kvDriver: KvDriver;
   prefixIterator: PrefixIterator<Uint8Array>;
 
-  constructor(kv: Deno.Kv) {
-    this.kvDriver = new KvDriverDeno(kv);
+  constructor(
+    opts: EntryDriverKvOpts<
+      NamespaceKey,
+      SubspaceKey,
+      PayloadDigest,
+      Fingerprint
+    >,
+  ) {
+    this.namespaceScheme = opts.namespaceScheme;
+    this.subspaceScheme = opts.subspaceScheme;
+    this.payloadScheme = opts.payloadScheme;
+    this.pathLengthScheme = opts.pathLengthScheme;
+    this.fingerprintScheme = opts.fingerprintScheme;
+
+    this.kvDriver = opts.kvDriver;
     this.prefixIterator = new KeyHopTree<Uint8Array>(this.kvDriver);
   }
 
-  createSummarisableStorage(
-    address: string,
-  ): SummarisableStorage<Uint8Array, Uint8Array> {
-    const prefixedDriver = new PrefixedDriver([address], this.kvDriver);
-
-    return new Skiplist({
-      monoid: sha256XorMonoid,
-      compare: compareBytes,
-      kv: prefixedDriver,
+  makeStorage(
+    namespace: NamespaceKey,
+  ): Storage3d<NamespaceKey, SubspaceKey, PayloadDigest, Fingerprint> {
+    return new TripleStorage({
+      namespace,
+      createSummarisableStorage: (
+        monoid: LiftingMonoid<Uint8Array, Fingerprint>,
+      ) => {
+        return new Skiplist({
+          kv: this.kvDriver,
+          monoid,
+          compare: compareBytes,
+        });
+      },
+      fingerprintScheme: this.fingerprintScheme,
+      pathLengthScheme: this.pathLengthScheme,
+      payloadScheme: this.payloadScheme,
+      subspaceScheme: this.subspaceScheme,
     });
   }
 
   writeAheadFlag = {
-    wasInserting: () => {
-      return this.kvDriver.get<[Uint8Array, Uint8Array]>([
+    wasInserting: async () => {
+      const maybeInsertion = await this.kvDriver.get<Uint8Array>([
         "waf",
         "insert",
       ]);
+
+      if (!maybeInsertion) {
+        return;
+      }
+
+      const probablyAuthTokenHash = await this.kvDriver.get<Uint8Array>([
+        "waf",
+        "insert",
+        "authTokenHash",
+      ]);
+
+      if (!probablyAuthTokenHash) {
+        console.warn(
+          "Write ahead flag: an insertion was detected, but no corresponding auth token was found.",
+        );
+
+        return;
+      }
+
+      const entry = decodeEntry(maybeInsertion, {
+        namespaceScheme: this.namespaceScheme,
+        subspaceScheme: this.subspaceScheme,
+        payloadScheme: this.payloadScheme,
+        pathLengthScheme: this.pathLengthScheme,
+      });
+
+      const authTokenHash = this.payloadScheme.decode(probablyAuthTokenHash);
+
+      return {
+        entry,
+        authTokenHash,
+      };
     },
-    wasRemoving: () => {
-      return this.kvDriver.get<Uint8Array>([
+    wasRemoving: async () => {
+      const maybeRemoval = await this.kvDriver.get<Uint8Array>([
         "waf",
         "remove",
       ]);
+
+      if (!maybeRemoval) {
+        return;
+      }
+
+      const entry = decodeEntry(maybeRemoval, {
+        namespaceScheme: this.namespaceScheme,
+        subspaceScheme: this.subspaceScheme,
+        payloadScheme: this.payloadScheme,
+        pathLengthScheme: this.pathLengthScheme,
+      });
+
+      return entry;
     },
-    flagInsertion: (key: Uint8Array, value: Uint8Array) => {
-      return this.kvDriver.set(["waf", "insert"], [key, value]);
+    flagInsertion: async (
+      entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest>,
+      authTokenHash: PayloadDigest,
+    ) => {
+      const entryEncoded = encodeEntry(entry, {
+        namespaceScheme: this.namespaceScheme,
+        subspaceScheme: this.subspaceScheme,
+        pathLengthScheme: this.pathLengthScheme,
+        payloadScheme: this.payloadScheme,
+      });
+
+      const authHashEncoded = this.payloadScheme.encode(authTokenHash);
+
+      await this.kvDriver.set(
+        ["waf", "insert"],
+        entryEncoded,
+      );
+
+      await this.kvDriver.set(
+        ["waf", "insert", "authTokenHash"],
+        authHashEncoded,
+      );
     },
-    flagRemoval: (key: Uint8Array) => {
-      return this.kvDriver.set(["waf", "remove"], key);
+
+    flagRemoval: (entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest>) => {
+      const entryEncoded = encodeEntry(entry, {
+        namespaceScheme: this.namespaceScheme,
+        subspaceScheme: this.subspaceScheme,
+        pathLengthScheme: this.pathLengthScheme,
+        payloadScheme: this.payloadScheme,
+      });
+
+      return this.kvDriver.set(["waf", "remove"], entryEncoded);
     },
-    unflagInsertion: () => {
-      return this.kvDriver.delete(["waf", "insert"]);
+
+    unflagInsertion: async () => {
+      await this.kvDriver.delete(["waf", "insert"]);
+      await this.kvDriver.delete(["waf", "insert", "authTokenHash"]);
     },
     unflagRemoval: () => {
-      {
-        return this.kvDriver.delete(["waf", "remove"]);
-      }
+      return this.kvDriver.delete(["waf", "remove"]);
     },
   };
 }

--- a/src/replica/storage/entry_drivers/memory.ts
+++ b/src/replica/storage/entry_drivers/memory.ts
@@ -1,25 +1,113 @@
 import { compareBytes } from "../../../util/bytes.ts";
+import {
+  FingerprintScheme,
+  PathLengthScheme,
+  PayloadScheme,
+  SubspaceScheme,
+} from "../../types.ts";
 import { RadixishTree } from "../prefix_iterators/radixish_tree.ts";
-import { sha256XorMonoid } from "../summarisable_storage/lifting_monoid.ts";
+
+import { LiftingMonoid } from "../summarisable_storage/lifting_monoid.ts";
 import { MonoidRbTree } from "../summarisable_storage/monoid_rbtree.ts";
-import { SummarisableStorage } from "../summarisable_storage/types.ts";
 import { EntryDriver } from "../types.ts";
+import { Storage3d } from "../storage_3d/types.ts";
+import { TripleStorage } from "../storage_3d/triple_storage.ts";
+import { Entry } from "../../../entries/types.ts";
+
+type EntryDriverMemoryOpts<
+  NamespaceKey,
+  SubspaceKey,
+  PayloadDigest,
+  Fingerprint,
+> = {
+  subspaceScheme: SubspaceScheme<SubspaceKey>;
+  payloadScheme: PayloadScheme<PayloadDigest>;
+  pathLengthScheme: PathLengthScheme;
+  fingerprintScheme: FingerprintScheme<
+    NamespaceKey,
+    SubspaceKey,
+    PayloadDigest,
+    Fingerprint
+  >;
+};
 
 /** Store and retrieve entries in memory. */
-export class EntryDriverMemory implements EntryDriver {
-  createSummarisableStorage(): SummarisableStorage<Uint8Array, Uint8Array> {
-    return new MonoidRbTree({
-      monoid: sha256XorMonoid,
-      compare: compareBytes,
+export class EntryDriverMemory<
+  NamespaceKey,
+  SubspaceKey,
+  PayloadDigest,
+  Fingerprint,
+> implements
+  EntryDriver<NamespaceKey, SubspaceKey, PayloadDigest, Fingerprint> {
+  constructor(
+    readonly opts: EntryDriverMemoryOpts<
+      NamespaceKey,
+      SubspaceKey,
+      PayloadDigest,
+      Fingerprint
+    >,
+  ) {}
+
+  private wafInsert:
+    | [Entry<NamespaceKey, SubspaceKey, PayloadDigest>, PayloadDigest]
+    | undefined;
+  private wafRemove:
+    | Entry<NamespaceKey, SubspaceKey, PayloadDigest>
+    | undefined;
+
+  makeStorage(
+    namespace: NamespaceKey,
+  ): Storage3d<NamespaceKey, SubspaceKey, PayloadDigest, Fingerprint> {
+    return new TripleStorage({
+      namespace,
+      createSummarisableStorage: (
+        monoid: LiftingMonoid<Uint8Array, Fingerprint>,
+      ) => {
+        return new MonoidRbTree({
+          monoid,
+          compare: compareBytes,
+        });
+      },
+      fingerprintScheme: this.opts.fingerprintScheme,
+      pathLengthScheme: this.opts.pathLengthScheme,
+      payloadScheme: this.opts.payloadScheme,
+      subspaceScheme: this.opts.subspaceScheme,
     });
   }
   writeAheadFlag = {
-    wasInserting: () => Promise.resolve(undefined),
-    wasRemoving: () => Promise.resolve(undefined),
-    flagInsertion: () => Promise.resolve(undefined),
-    flagRemoval: () => Promise.resolve(undefined),
-    unflagInsertion: () => Promise.resolve(undefined),
-    unflagRemoval: () => Promise.resolve(undefined),
+    wasInserting: () => {
+      if (!this.wafInsert) {
+        return Promise.resolve(undefined);
+      }
+
+      const [entry, authTokenHash] = this.wafInsert;
+
+      return Promise.resolve({ entry, authTokenHash });
+    },
+    wasRemoving: () => {
+      return Promise.resolve(this.wafRemove);
+    },
+    flagInsertion: (
+      entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest>,
+      authTokenHash: PayloadDigest,
+    ) => {
+      this.wafInsert = [entry, authTokenHash];
+
+      return Promise.resolve();
+    },
+    flagRemoval: (entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest>) => {
+      this.wafRemove = entry;
+
+      return Promise.resolve();
+    },
+    unflagInsertion: () => {
+      this.wafInsert = undefined;
+      return Promise.resolve();
+    },
+    unflagRemoval: () => {
+      this.wafRemove = undefined;
+      return Promise.resolve();
+    },
   };
   prefixIterator = new RadixishTree<Uint8Array>();
 }

--- a/src/replica/storage/payload_drivers/filesystem.ts
+++ b/src/replica/storage/payload_drivers/filesystem.ts
@@ -1,10 +1,10 @@
-import { encodeBase32 } from "$std/encoding/base32.ts";
 import { ValidationError, WillowError } from "../../../errors.ts";
 import { EncodingScheme, Payload } from "../../types.ts";
 import { PayloadDriver } from "../types.ts";
 import { join } from "https://deno.land/std@0.188.0/path/mod.ts";
 import { ensureDir } from "https://deno.land/std@0.188.0/fs/ensure_dir.ts";
 import { move } from "https://deno.land/std@0.188.0/fs/move.ts";
+import { encodeBase32 } from "../../../../deps.ts";
 
 /** Stores and retrieves payloads from the filesystem. */
 export class PayloadDriverFilesystem<PayloadDigest>

--- a/src/replica/storage/payload_drivers/memory.ts
+++ b/src/replica/storage/payload_drivers/memory.ts
@@ -1,5 +1,4 @@
-import { encodeBase64 } from "$std/encoding/base64.ts";
-import { toArrayBuffer } from "$std/streams/to_array_buffer.ts";
+import { encodeBase64, toArrayBuffer } from "../../../../deps.ts";
 import { ValidationError } from "../../../errors.ts";
 import { EncodingScheme, Payload } from "../../types.ts";
 import { PayloadDriver } from "../types.ts";

--- a/src/replica/storage/prefix_iterators/key_hop_tree.ts
+++ b/src/replica/storage/prefix_iterators/key_hop_tree.ts
@@ -1,5 +1,4 @@
-import { concat } from "$std/bytes/concat.ts";
-import { equals as bytesEquals } from "$std/bytes/equals.ts";
+import { concat, equalsBytes } from "../../../../deps.ts";
 import { compareBytes, incrementLastByte } from "../../../util/bytes.ts";
 import { KvBatch, KvDriver } from "../kv/types.ts";
 
@@ -183,7 +182,7 @@ export class KeyHopTree<ValueType> {
     // First check if the key + vector is a prefix of ours.
     const completeValue = concat(searchKey, existingNode[1]);
 
-    if (bytesEquals(completeValue, key)) {
+    if (equalsBytes(completeValue, key)) {
       const batch = this.kv.batch();
 
       if (existingNode[0] === Phantomness.RealWithPhantom) {
@@ -321,7 +320,7 @@ export class KeyHopTree<ValueType> {
 
       const completeVal = concat(searchKey, node[1]);
 
-      if (bytesEquals(completeVal, key)) {
+      if (equalsBytes(completeVal, key)) {
         break;
       }
 
@@ -354,7 +353,7 @@ export class KeyHopTree<ValueType> {
         entry.value[1],
       );
 
-      if (bytesEquals(completeVal, key)) {
+      if (equalsBytes(completeVal, key)) {
         continue;
       }
 

--- a/src/replica/storage/prefix_iterators/prefix_iterator.test.ts
+++ b/src/replica/storage/prefix_iterators/prefix_iterator.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "$std/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.202.0/testing/asserts.ts";
 import { RadixishTree } from "./radixish_tree.ts";
 import { PrefixIterator } from "./types.ts";
 import { KeyHopTree } from "./key_hop_tree.ts";

--- a/src/replica/storage/prefix_iterators/simple_key_iterator.ts
+++ b/src/replica/storage/prefix_iterators/simple_key_iterator.ts
@@ -1,4 +1,4 @@
-import { equals as bytesEquals } from "$std/bytes/equals.ts";
+import { equalsBytes } from "../../../../deps.ts";
 import { compareBytes, incrementLastByte } from "../../../util/bytes.ts";
 import { Key, KvDriver } from "../kv/types.ts";
 
@@ -69,7 +69,7 @@ export class SimpleKeyIterator<ValueType> {
         end: [incrementLastByte(key)],
       })
     ) {
-      if (bytesEquals(entry.key[0] as Uint8Array, key)) {
+      if (equalsBytes(entry.key[0] as Uint8Array, key)) {
         continue;
       }
 

--- a/src/replica/storage/storage_3d/storage_3d.test.ts
+++ b/src/replica/storage/storage_3d/storage_3d.test.ts
@@ -1,0 +1,496 @@
+import { assert } from "https://deno.land/std@0.202.0/assert/assert.ts";
+import { encodeBase32, encodeBase64, Products } from "../../../../deps.ts";
+import {
+  makeNamespaceKeypair,
+  makeSubspaceKeypair,
+} from "../../../test/crypto.ts";
+import {
+  testSchemeAuthorisation,
+  testSchemeFingerprint,
+  testSchemeNamespace,
+  testSchemePathLength,
+  testSchemePayload,
+  testSchemeSubspace,
+} from "../../../test/test_schemes.ts";
+import { getSubspaces, randomTimestamp } from "../../../test/utils.ts";
+import { compareBytes } from "../../../util/bytes.ts";
+import { Replica } from "../../replica.ts";
+import { OptionalBounds, Query } from "../../types.ts";
+import { RadixishTree } from "../prefix_iterators/radixish_tree.ts";
+import { MonoidRbTree } from "../summarisable_storage/monoid_rbtree.ts";
+import { TripleStorage } from "./triple_storage.ts";
+import { Storage3d } from "./types.ts";
+import { sample } from "https://deno.land/std@0.198.0/collections/sample.ts";
+import { encodeEntry } from "../../../entries/encode_decode.ts";
+import { assertEquals } from "https://deno.land/std@0.202.0/assert/assert_equals.ts";
+import { Entry } from "../../../entries/types.ts";
+
+const emptyUi8 = new Uint8Array();
+
+type Storage3dScenario<NamespaceKey, SubspaceKey, PayloadDigest, Fingerprint> =
+  {
+    name: string;
+    makeScenario: (namespace: NamespaceKey) => Promise<
+      {
+        storage: Storage3d<
+          NamespaceKey,
+          SubspaceKey,
+          PayloadDigest,
+          Fingerprint
+        >;
+        dispose: () => Promise<void>;
+      }
+    >;
+  };
+
+const tripleStorageScenario: Storage3dScenario<
+  Uint8Array,
+  Uint8Array,
+  ArrayBuffer,
+  Uint8Array
+> = {
+  name: "Triple storage",
+  makeScenario: (namespace) => {
+    const storage = new TripleStorage({
+      namespace,
+      subspaceScheme: testSchemeSubspace,
+      pathLengthScheme: testSchemePathLength,
+      payloadScheme: testSchemePayload,
+      fingerprintScheme: testSchemeFingerprint,
+      createSummarisableStorage: (monoid) => {
+        return new MonoidRbTree({
+          monoid,
+          compare: compareBytes,
+        });
+      },
+    });
+
+    return Promise.resolve({ storage, dispose: () => Promise.resolve() });
+  },
+};
+
+const scenarios = [tripleStorageScenario];
+
+Deno.test("entriesByQuery", async () => {
+  // Items must come in right order
+  // Must use bound correctly
+  // Must respect limit
+  // Must respect reverse
+
+  // Create a replica.
+
+  // Insert a random number of entries.
+
+  // Hold onto these entries for checking presence later
+
+  for (const scenario of scenarios) {
+    const namespaceKeypair = await makeNamespaceKeypair();
+
+    const { storage, dispose } = await scenario.makeScenario(
+      namespaceKeypair.namespace,
+    );
+
+    const replica = new Replica({
+      namespace: namespaceKeypair.namespace,
+      protocolParameters: {
+        authorisationScheme: testSchemeAuthorisation,
+        namespaceScheme: testSchemeNamespace,
+        subspaceScheme: testSchemeSubspace,
+        pathLengthScheme: testSchemePathLength,
+        payloadScheme: testSchemePayload,
+        fingerprintScheme: testSchemeFingerprint,
+      },
+      entryDriver: {
+        makeStorage: () => {
+          return storage;
+        },
+        prefixIterator: new RadixishTree<Uint8Array>(),
+        writeAheadFlag: {
+          wasInserting: () => Promise.resolve(undefined),
+          wasRemoving: () => Promise.resolve(undefined),
+          flagInsertion: () => Promise.resolve(),
+          flagRemoval: () => Promise.resolve(),
+          unflagInsertion: () => Promise.resolve(),
+          unflagRemoval: () => Promise.resolve(),
+        },
+      },
+    });
+
+    // Generate the test queries
+
+    const subspaces = await getSubspaces(10);
+    const bytes = [];
+
+    for (let i = 0; i < 50; i++) {
+      bytes.push(crypto.getRandomValues(new Uint8Array(4)));
+    }
+
+    const timestamps = [];
+
+    for (let i = 0; i < 25; i++) {
+      timestamps.push(randomTimestamp());
+    }
+
+    // Bounds
+
+    const subspaceBounds = manyRandomBounds(
+      100,
+      subspaces.map((s) => s.subspace),
+      compareBytes,
+    );
+    const pathBounds = manyRandomBounds(100, bytes, Products.orderPaths);
+    const timeBounds = manyRandomBounds(
+      100,
+      timestamps,
+      Products.orderTimestamps,
+    );
+
+    const queries: Query<Uint8Array>[] = [];
+
+    const includedByQueries = (
+      subspace: Uint8Array,
+      path: Uint8Array,
+      time: bigint,
+    ): Query<Uint8Array>[] => {
+      const includedQueries = [];
+
+      for (const query of queries) {
+        if (query.subspace) {
+          const range = rangeFromOptionalBounds(query.subspace, emptyUi8);
+
+          const isIncluded = Products.rangeIncludesValue(
+            { order: compareBytes },
+            range,
+            subspace,
+          );
+
+          if (!isIncluded) {
+            continue;
+          }
+        }
+
+        if (query.path) {
+          const range = rangeFromOptionalBounds(query.path, emptyUi8);
+
+          const isIncluded = Products.rangeIncludesValue(
+            { order: Products.orderPaths },
+            range,
+            path,
+          );
+
+          if (!isIncluded) {
+            continue;
+          }
+        }
+
+        if (query.time) {
+          const range = rangeFromOptionalBounds(query.time, BigInt(0));
+
+          const isIncluded = Products.rangeIncludesValue(
+            { order: Products.orderTimestamps },
+            range,
+            time,
+          );
+
+          if (!isIncluded) {
+            continue;
+          }
+        }
+
+        includedQueries.push(query);
+      }
+
+      return includedQueries;
+    };
+
+    for (let i = 0; i < 500; i++) {
+      const orderRoll = Math.random();
+
+      const query: Query<Uint8Array> = {
+        limit: Math.random() < 0.1 ? Math.floor(Math.random() * 10) : undefined,
+        reverse: Math.random() < 0.25 ? true : false,
+        order: orderRoll < 0.33
+          ? "subspace"
+          : orderRoll < 0.66
+          ? "path"
+          : "timestamp",
+        subspace: Math.random() < 0.5 ? sample(subspaceBounds) : undefined,
+        path: Math.random() < 0.5 ? sample(pathBounds) : undefined,
+        time: Math.random() < 0.5 ? sample(timeBounds) : undefined,
+      };
+
+      queries.push(query);
+    }
+
+    const queryInclusionMap = new Map<
+      Query<Uint8Array>,
+      Set<string>
+    >();
+
+    for (const query of queries) {
+      queryInclusionMap.set(query, new Set());
+    }
+
+    replica.addEventListener("entryremove", (event) => {
+      const { detail: { removed } } = event as CustomEvent<
+        { removed: Entry<Uint8Array, Uint8Array, Uint8Array> }
+      >;
+
+      const encodedEntry = encodeEntry(removed, {
+        namespaceScheme: testSchemeNamespace,
+        subspaceScheme: testSchemeSubspace,
+        pathLengthScheme: testSchemePathLength,
+        payloadScheme: testSchemePayload,
+      });
+
+      testSchemePayload.fromBytes(encodedEntry).then((hash) => {
+        const b64 = encodeBase64(hash);
+
+        for (const [, set] of queryInclusionMap) {
+          set.delete(b64);
+        }
+      });
+    });
+
+    const entryAuthHashMap = new Map<string, string>();
+
+    // Generate the entries
+    for (let i = 0; i < 50; i++) {
+      const pathAndPayload = sample(bytes)!;
+      const chosenSubspace = sample(subspaces)!;
+      const timestamp = sample(timestamps)!;
+
+      const result = await replica.set({
+        path: pathAndPayload,
+        payload: pathAndPayload,
+        subspace: chosenSubspace.subspace,
+        timestamp,
+      }, chosenSubspace.privateKey);
+
+      if (result.kind !== "success") {
+        continue;
+      }
+
+      // See if it belongs to any of the test queries.
+      const correspondingQueries = includedByQueries(
+        chosenSubspace.subspace,
+        pathAndPayload,
+        timestamp,
+      );
+
+      const encodedEntry = encodeEntry(result.entry, {
+        namespaceScheme: testSchemeNamespace,
+        subspaceScheme: testSchemeSubspace,
+        pathLengthScheme: testSchemePathLength,
+        payloadScheme: testSchemePayload,
+      });
+
+      const entryHash = await testSchemePayload.fromBytes(encodedEntry);
+
+      const b64EntryHash = encodeBase64(entryHash);
+
+      // We'll use a base64 encoding of the entry's signature as an ID
+      const authTokenHash = await testSchemePayload.fromBytes(
+        new Uint8Array(result.authToken),
+      );
+      const b64AuthHash = encodeBase64(authTokenHash);
+
+      entryAuthHashMap.set(b64EntryHash, b64AuthHash);
+
+      for (const query of correspondingQueries) {
+        const set = queryInclusionMap.get(query)!;
+
+        set.add(b64EntryHash);
+      }
+    }
+
+    for (const query of queries) {
+      let entriesRead = 0;
+
+      const awaiting = new Set(queryInclusionMap.get(query));
+
+      const prevIsCorrectOrder = (
+        prev: Entry<Uint8Array, Uint8Array, ArrayBuffer>,
+        curr: Entry<Uint8Array, Uint8Array, ArrayBuffer>,
+        ord: "path" | "timestamp" | "subspace",
+      ): boolean => {
+        switch (ord) {
+          case "path": {
+            const order = compareBytes(
+              prev.identifier.path,
+              curr.identifier.path,
+            );
+
+            if (order === 0) {
+              return prevIsCorrectOrder(prev, curr, "timestamp");
+            }
+
+            if (query.reverse) {
+              return order === 1;
+            }
+
+            return order === -1;
+          }
+          case "timestamp": {
+            const order = Products.orderTimestamps(
+              prev.record.timestamp,
+              curr.record.timestamp,
+            );
+
+            if (order === 0) {
+              return prevIsCorrectOrder(prev, curr, "subspace");
+            }
+
+            if (query.reverse) {
+              return order === 1;
+            }
+
+            return order === -1;
+          }
+          case "subspace": {
+            const order = compareBytes(
+              prev.identifier.subspace,
+              curr.identifier.subspace,
+            );
+
+            if (order === 0) {
+              return prevIsCorrectOrder(prev, curr, "path");
+            }
+
+            if (query.reverse) {
+              return order === 1;
+            }
+
+            return order === -1;
+          }
+        }
+      };
+
+      let prevEntry: Entry<Uint8Array, Uint8Array, ArrayBuffer> | undefined;
+
+      for await (
+        const { entry, authTokenHash } of storage.entriesByQuery(query)
+      ) {
+        const encodedEntry = encodeEntry(entry, {
+          namespaceScheme: testSchemeNamespace,
+          subspaceScheme: testSchemeSubspace,
+          pathLengthScheme: testSchemePathLength,
+          payloadScheme: testSchemePayload,
+        });
+
+        const entryHash = await testSchemePayload.fromBytes(encodedEntry);
+
+        const b64EntryHash = encodeBase64(entryHash);
+
+        // We'll use a base64 encoding of the entry's signature as an ID
+        const b64AuthHash = encodeBase64(authTokenHash);
+
+        assertEquals(entryAuthHashMap.get(b64EntryHash), b64AuthHash);
+
+        // Test order
+        if (prevEntry) {
+          assert(prevIsCorrectOrder(prevEntry, entry, query.order));
+        }
+
+        assert(queryInclusionMap.get(query)?.has(b64EntryHash));
+        entriesRead += 1;
+        prevEntry = entry;
+
+        awaiting.delete(b64EntryHash);
+
+        if (query.limit && entriesRead > query.limit) {
+          assert(false, "Too many entries received for query");
+        }
+      }
+
+      if (query.limit) {
+        assertEquals(
+          entriesRead,
+          Math.min(query.limit, queryInclusionMap.get(query)!.size),
+        );
+      } else {
+        assertEquals(entriesRead, queryInclusionMap.get(query)!.size);
+      }
+    }
+  }
+});
+
+function manyRandomBounds<ValueType>(
+  size: number,
+  sampleFrom: Array<ValueType>,
+  order: Products.TotalOrder<ValueType>,
+) {
+  const bounds = [];
+
+  for (let i = 0; i < size; i++) {
+    bounds.push(randomBounds(sampleFrom, order));
+  }
+
+  return bounds;
+}
+
+function randomBounds<ValueType>(
+  sampleFrom: Array<ValueType>,
+  order: Products.TotalOrder<ValueType>,
+): OptionalBounds<ValueType> {
+  const kindRoll = Math.random();
+
+  if (kindRoll < 0.33) {
+    return {
+      lowerBound: sample(sampleFrom)!,
+    };
+  } else if (kindRoll < 0.66) {
+    return {
+      upperBound: sample(sampleFrom)!,
+    };
+  }
+
+  while (true) {
+    const fst = sample(sampleFrom)!;
+    const snd = sample(sampleFrom)!;
+
+    const fstSndOrder = order(fst, snd);
+
+    if (fstSndOrder === 0) {
+      continue;
+    }
+
+    if (fstSndOrder === -1) {
+      return {
+        lowerBound: fst,
+        upperBound: snd,
+      };
+    }
+
+    return {
+      lowerBound: snd,
+      upperBound: fst,
+    };
+  }
+}
+
+function rangeFromOptionalBounds<ValueType>(
+  bounds: OptionalBounds<ValueType>,
+  leastValue: ValueType,
+): Products.Range<ValueType> {
+  if (bounds.lowerBound && !bounds.upperBound) {
+    return {
+      kind: "open",
+      start: bounds.lowerBound,
+    };
+  }
+
+  if (bounds.upperBound && !bounds.lowerBound) {
+    return {
+      kind: "closed_exclusive",
+      start: leastValue,
+      end: bounds.upperBound,
+    };
+  }
+
+  return {
+    kind: "closed_exclusive",
+    start: bounds.lowerBound!,
+    end: bounds.upperBound!,
+  };
+}

--- a/src/replica/storage/storage_3d/storage_3d.test.ts
+++ b/src/replica/storage/storage_3d/storage_3d.test.ts
@@ -1,5 +1,5 @@
 import { assert } from "https://deno.land/std@0.202.0/assert/assert.ts";
-import { encodeBase32, encodeBase64, Products } from "../../../../deps.ts";
+import { encodeBase64, Products } from "../../../../deps.ts";
 import {
   makeNamespaceKeypair,
   makeSubspaceKeypair,
@@ -71,18 +71,51 @@ const tripleStorageScenario: Storage3dScenario<
 
 const scenarios = [tripleStorageScenario];
 
-Deno.test("entriesByQuery", async () => {
-  // Items must come in right order
-  // Must use bound correctly
-  // Must respect limit
-  // Must respect reverse
+Deno.test("Storage3d.insert, get, and remove", async (test) => {
+  for (const scenario of scenarios) {
+    const namespaceKeypair = await makeNamespaceKeypair();
 
-  // Create a replica.
+    const { storage, dispose } = await scenario.makeScenario(
+      namespaceKeypair.namespace,
+    );
 
-  // Insert a random number of entries.
+    await test.step(scenario.name, async () => {
+      const subspace = await makeSubspaceKeypair();
+      const pathAndPayload = crypto.getRandomValues(new Uint8Array(8));
 
-  // Hold onto these entries for checking presence later
+      const payloadHash = crypto.getRandomValues(new Uint8Array(32));
+      const authTokenHash = crypto.getRandomValues(new Uint8Array(32));
 
+      await storage.insert({
+        path: pathAndPayload,
+        payloadHash,
+        authTokenHash,
+        length: BigInt(8),
+        subspace: subspace.subspace,
+        timestamp: BigInt(1000),
+      });
+
+      const res = await storage.get(subspace.subspace, pathAndPayload);
+
+      assert(res);
+
+      assertEquals(res.entry.identifier.subspace, subspace.subspace);
+      assertEquals(res.entry.identifier.path, pathAndPayload);
+      assertEquals(res.entry.record.hash, payloadHash);
+      assertEquals(res.authTokenHash, authTokenHash);
+
+      await storage.remove(res.entry);
+
+      const res2 = await storage.get(subspace.subspace, pathAndPayload);
+
+      assert(res2 === undefined);
+    });
+
+    await dispose();
+  }
+});
+
+Deno.test("Storage3d.entriesByQuery", async (test) => {
   for (const scenario of scenarios) {
     const namespaceKeypair = await makeNamespaceKeypair();
 
@@ -116,262 +149,172 @@ Deno.test("entriesByQuery", async () => {
       },
     });
 
-    // Generate the test queries
+    await test.step(scenario.name, async () => {
+      // Generate the test queries
 
-    const subspaces = await getSubspaces(10);
-    const bytes = [];
+      const subspaces = await getSubspaces(10);
+      const bytes = [];
 
-    for (let i = 0; i < 50; i++) {
-      bytes.push(crypto.getRandomValues(new Uint8Array(4)));
-    }
+      for (let i = 0; i < 50; i++) {
+        bytes.push(crypto.getRandomValues(new Uint8Array(4)));
+      }
 
-    const timestamps = [];
+      const timestamps = [];
 
-    for (let i = 0; i < 25; i++) {
-      timestamps.push(randomTimestamp());
-    }
+      for (let i = 0; i < 25; i++) {
+        timestamps.push(randomTimestamp());
+      }
 
-    // Bounds
+      // Bounds
 
-    const subspaceBounds = manyRandomBounds(
-      100,
-      subspaces.map((s) => s.subspace),
-      compareBytes,
-    );
-    const pathBounds = manyRandomBounds(100, bytes, Products.orderPaths);
-    const timeBounds = manyRandomBounds(
-      100,
-      timestamps,
-      Products.orderTimestamps,
-    );
+      const subspaceBounds = manyRandomBounds(
+        100,
+        subspaces.map((s) => s.subspace),
+        compareBytes,
+      );
+      const pathBounds = manyRandomBounds(100, bytes, Products.orderPaths);
+      const timeBounds = manyRandomBounds(
+        100,
+        timestamps,
+        Products.orderTimestamps,
+      );
 
-    const queries: Query<Uint8Array>[] = [];
+      const queries: Query<Uint8Array>[] = [];
 
-    const includedByQueries = (
-      subspace: Uint8Array,
-      path: Uint8Array,
-      time: bigint,
-    ): Query<Uint8Array>[] => {
-      const includedQueries = [];
+      const includedByQueries = (
+        subspace: Uint8Array,
+        path: Uint8Array,
+        time: bigint,
+      ): Query<Uint8Array>[] => {
+        const includedQueries = [];
+
+        for (const query of queries) {
+          if (query.subspace) {
+            const range = rangeFromOptionalBounds(query.subspace, emptyUi8);
+
+            const isIncluded = Products.rangeIncludesValue(
+              { order: compareBytes },
+              range,
+              subspace,
+            );
+
+            if (!isIncluded) {
+              continue;
+            }
+          }
+
+          if (query.path) {
+            const range = rangeFromOptionalBounds(query.path, emptyUi8);
+
+            const isIncluded = Products.rangeIncludesValue(
+              { order: Products.orderPaths },
+              range,
+              path,
+            );
+
+            if (!isIncluded) {
+              continue;
+            }
+          }
+
+          if (query.time) {
+            const range = rangeFromOptionalBounds(query.time, BigInt(0));
+
+            const isIncluded = Products.rangeIncludesValue(
+              { order: Products.orderTimestamps },
+              range,
+              time,
+            );
+
+            if (!isIncluded) {
+              continue;
+            }
+          }
+
+          includedQueries.push(query);
+        }
+
+        return includedQueries;
+      };
+
+      for (let i = 0; i < 500; i++) {
+        const orderRoll = Math.random();
+
+        const query: Query<Uint8Array> = {
+          limit: Math.random() < 0.1
+            ? Math.floor(Math.random() * 10)
+            : undefined,
+          reverse: Math.random() < 0.25 ? true : false,
+          order: orderRoll < 0.33
+            ? "subspace"
+            : orderRoll < 0.66
+            ? "path"
+            : "timestamp",
+          subspace: Math.random() < 0.5 ? sample(subspaceBounds) : undefined,
+          path: Math.random() < 0.5 ? sample(pathBounds) : undefined,
+          time: Math.random() < 0.5 ? sample(timeBounds) : undefined,
+        };
+
+        queries.push(query);
+      }
+
+      const queryInclusionMap = new Map<
+        Query<Uint8Array>,
+        Set<string>
+      >();
 
       for (const query of queries) {
-        if (query.subspace) {
-          const range = rangeFromOptionalBounds(query.subspace, emptyUi8);
-
-          const isIncluded = Products.rangeIncludesValue(
-            { order: compareBytes },
-            range,
-            subspace,
-          );
-
-          if (!isIncluded) {
-            continue;
-          }
-        }
-
-        if (query.path) {
-          const range = rangeFromOptionalBounds(query.path, emptyUi8);
-
-          const isIncluded = Products.rangeIncludesValue(
-            { order: Products.orderPaths },
-            range,
-            path,
-          );
-
-          if (!isIncluded) {
-            continue;
-          }
-        }
-
-        if (query.time) {
-          const range = rangeFromOptionalBounds(query.time, BigInt(0));
-
-          const isIncluded = Products.rangeIncludesValue(
-            { order: Products.orderTimestamps },
-            range,
-            time,
-          );
-
-          if (!isIncluded) {
-            continue;
-          }
-        }
-
-        includedQueries.push(query);
+        queryInclusionMap.set(query, new Set());
       }
 
-      return includedQueries;
-    };
+      replica.addEventListener("entryremove", (event) => {
+        const { detail: { removed } } = event as CustomEvent<
+          { removed: Entry<Uint8Array, Uint8Array, Uint8Array> }
+        >;
 
-    for (let i = 0; i < 500; i++) {
-      const orderRoll = Math.random();
+        const encodedEntry = encodeEntry(removed, {
+          namespaceScheme: testSchemeNamespace,
+          subspaceScheme: testSchemeSubspace,
+          pathLengthScheme: testSchemePathLength,
+          payloadScheme: testSchemePayload,
+        });
 
-      const query: Query<Uint8Array> = {
-        limit: Math.random() < 0.1 ? Math.floor(Math.random() * 10) : undefined,
-        reverse: Math.random() < 0.25 ? true : false,
-        order: orderRoll < 0.33
-          ? "subspace"
-          : orderRoll < 0.66
-          ? "path"
-          : "timestamp",
-        subspace: Math.random() < 0.5 ? sample(subspaceBounds) : undefined,
-        path: Math.random() < 0.5 ? sample(pathBounds) : undefined,
-        time: Math.random() < 0.5 ? sample(timeBounds) : undefined,
-      };
+        testSchemePayload.fromBytes(encodedEntry).then((hash) => {
+          const b64 = encodeBase64(hash);
 
-      queries.push(query);
-    }
-
-    const queryInclusionMap = new Map<
-      Query<Uint8Array>,
-      Set<string>
-    >();
-
-    for (const query of queries) {
-      queryInclusionMap.set(query, new Set());
-    }
-
-    replica.addEventListener("entryremove", (event) => {
-      const { detail: { removed } } = event as CustomEvent<
-        { removed: Entry<Uint8Array, Uint8Array, Uint8Array> }
-      >;
-
-      const encodedEntry = encodeEntry(removed, {
-        namespaceScheme: testSchemeNamespace,
-        subspaceScheme: testSchemeSubspace,
-        pathLengthScheme: testSchemePathLength,
-        payloadScheme: testSchemePayload,
+          for (const [, set] of queryInclusionMap) {
+            set.delete(b64);
+          }
+        });
       });
 
-      testSchemePayload.fromBytes(encodedEntry).then((hash) => {
-        const b64 = encodeBase64(hash);
+      const entryAuthHashMap = new Map<string, string>();
 
-        for (const [, set] of queryInclusionMap) {
-          set.delete(b64);
+      // Generate the entries
+      for (let i = 0; i < 50; i++) {
+        const pathAndPayload = sample(bytes)!;
+        const chosenSubspace = sample(subspaces)!;
+        const timestamp = sample(timestamps)!;
+
+        const result = await replica.set({
+          path: pathAndPayload,
+          payload: pathAndPayload,
+          subspace: chosenSubspace.subspace,
+          timestamp,
+        }, chosenSubspace.privateKey);
+
+        if (result.kind !== "success") {
+          continue;
         }
-      });
-    });
 
-    const entryAuthHashMap = new Map<string, string>();
+        // See if it belongs to any of the test queries.
+        const correspondingQueries = includedByQueries(
+          chosenSubspace.subspace,
+          pathAndPayload,
+          timestamp,
+        );
 
-    // Generate the entries
-    for (let i = 0; i < 50; i++) {
-      const pathAndPayload = sample(bytes)!;
-      const chosenSubspace = sample(subspaces)!;
-      const timestamp = sample(timestamps)!;
-
-      const result = await replica.set({
-        path: pathAndPayload,
-        payload: pathAndPayload,
-        subspace: chosenSubspace.subspace,
-        timestamp,
-      }, chosenSubspace.privateKey);
-
-      if (result.kind !== "success") {
-        continue;
-      }
-
-      // See if it belongs to any of the test queries.
-      const correspondingQueries = includedByQueries(
-        chosenSubspace.subspace,
-        pathAndPayload,
-        timestamp,
-      );
-
-      const encodedEntry = encodeEntry(result.entry, {
-        namespaceScheme: testSchemeNamespace,
-        subspaceScheme: testSchemeSubspace,
-        pathLengthScheme: testSchemePathLength,
-        payloadScheme: testSchemePayload,
-      });
-
-      const entryHash = await testSchemePayload.fromBytes(encodedEntry);
-
-      const b64EntryHash = encodeBase64(entryHash);
-
-      // We'll use a base64 encoding of the entry's signature as an ID
-      const authTokenHash = await testSchemePayload.fromBytes(
-        new Uint8Array(result.authToken),
-      );
-      const b64AuthHash = encodeBase64(authTokenHash);
-
-      entryAuthHashMap.set(b64EntryHash, b64AuthHash);
-
-      for (const query of correspondingQueries) {
-        const set = queryInclusionMap.get(query)!;
-
-        set.add(b64EntryHash);
-      }
-    }
-
-    for (const query of queries) {
-      let entriesRead = 0;
-
-      const awaiting = new Set(queryInclusionMap.get(query));
-
-      const prevIsCorrectOrder = (
-        prev: Entry<Uint8Array, Uint8Array, ArrayBuffer>,
-        curr: Entry<Uint8Array, Uint8Array, ArrayBuffer>,
-        ord: "path" | "timestamp" | "subspace",
-      ): boolean => {
-        switch (ord) {
-          case "path": {
-            const order = compareBytes(
-              prev.identifier.path,
-              curr.identifier.path,
-            );
-
-            if (order === 0) {
-              return prevIsCorrectOrder(prev, curr, "timestamp");
-            }
-
-            if (query.reverse) {
-              return order === 1;
-            }
-
-            return order === -1;
-          }
-          case "timestamp": {
-            const order = Products.orderTimestamps(
-              prev.record.timestamp,
-              curr.record.timestamp,
-            );
-
-            if (order === 0) {
-              return prevIsCorrectOrder(prev, curr, "subspace");
-            }
-
-            if (query.reverse) {
-              return order === 1;
-            }
-
-            return order === -1;
-          }
-          case "subspace": {
-            const order = compareBytes(
-              prev.identifier.subspace,
-              curr.identifier.subspace,
-            );
-
-            if (order === 0) {
-              return prevIsCorrectOrder(prev, curr, "path");
-            }
-
-            if (query.reverse) {
-              return order === 1;
-            }
-
-            return order === -1;
-          }
-        }
-      };
-
-      let prevEntry: Entry<Uint8Array, Uint8Array, ArrayBuffer> | undefined;
-
-      for await (
-        const { entry, authTokenHash } of storage.entriesByQuery(query)
-      ) {
-        const encodedEntry = encodeEntry(entry, {
+        const encodedEntry = encodeEntry(result.entry, {
           namespaceScheme: testSchemeNamespace,
           subspaceScheme: testSchemeSubspace,
           pathLengthScheme: testSchemePathLength,
@@ -383,35 +326,131 @@ Deno.test("entriesByQuery", async () => {
         const b64EntryHash = encodeBase64(entryHash);
 
         // We'll use a base64 encoding of the entry's signature as an ID
+        const authTokenHash = await testSchemePayload.fromBytes(
+          new Uint8Array(result.authToken),
+        );
         const b64AuthHash = encodeBase64(authTokenHash);
 
-        assertEquals(entryAuthHashMap.get(b64EntryHash), b64AuthHash);
+        entryAuthHashMap.set(b64EntryHash, b64AuthHash);
 
-        // Test order
-        if (prevEntry) {
-          assert(prevIsCorrectOrder(prevEntry, entry, query.order));
-        }
+        for (const query of correspondingQueries) {
+          const set = queryInclusionMap.get(query)!;
 
-        assert(queryInclusionMap.get(query)?.has(b64EntryHash));
-        entriesRead += 1;
-        prevEntry = entry;
-
-        awaiting.delete(b64EntryHash);
-
-        if (query.limit && entriesRead > query.limit) {
-          assert(false, "Too many entries received for query");
+          set.add(b64EntryHash);
         }
       }
 
-      if (query.limit) {
-        assertEquals(
-          entriesRead,
-          Math.min(query.limit, queryInclusionMap.get(query)!.size),
-        );
-      } else {
-        assertEquals(entriesRead, queryInclusionMap.get(query)!.size);
+      for (const query of queries) {
+        let entriesRead = 0;
+
+        const awaiting = new Set(queryInclusionMap.get(query));
+
+        const prevIsCorrectOrder = (
+          prev: Entry<Uint8Array, Uint8Array, ArrayBuffer>,
+          curr: Entry<Uint8Array, Uint8Array, ArrayBuffer>,
+          ord: "path" | "timestamp" | "subspace",
+        ): boolean => {
+          switch (ord) {
+            case "path": {
+              const order = compareBytes(
+                prev.identifier.path,
+                curr.identifier.path,
+              );
+
+              if (order === 0) {
+                return prevIsCorrectOrder(prev, curr, "timestamp");
+              }
+
+              if (query.reverse) {
+                return order === 1;
+              }
+
+              return order === -1;
+            }
+            case "timestamp": {
+              const order = Products.orderTimestamps(
+                prev.record.timestamp,
+                curr.record.timestamp,
+              );
+
+              if (order === 0) {
+                return prevIsCorrectOrder(prev, curr, "subspace");
+              }
+
+              if (query.reverse) {
+                return order === 1;
+              }
+
+              return order === -1;
+            }
+            case "subspace": {
+              const order = compareBytes(
+                prev.identifier.subspace,
+                curr.identifier.subspace,
+              );
+
+              if (order === 0) {
+                return prevIsCorrectOrder(prev, curr, "path");
+              }
+
+              if (query.reverse) {
+                return order === 1;
+              }
+
+              return order === -1;
+            }
+          }
+        };
+
+        let prevEntry: Entry<Uint8Array, Uint8Array, ArrayBuffer> | undefined;
+
+        for await (
+          const { entry, authTokenHash } of storage.entriesByQuery(query)
+        ) {
+          const encodedEntry = encodeEntry(entry, {
+            namespaceScheme: testSchemeNamespace,
+            subspaceScheme: testSchemeSubspace,
+            pathLengthScheme: testSchemePathLength,
+            payloadScheme: testSchemePayload,
+          });
+
+          const entryHash = await testSchemePayload.fromBytes(encodedEntry);
+
+          const b64EntryHash = encodeBase64(entryHash);
+
+          // We'll use a base64 encoding of the entry's signature as an ID
+          const b64AuthHash = encodeBase64(authTokenHash);
+
+          assertEquals(entryAuthHashMap.get(b64EntryHash), b64AuthHash);
+
+          // Test order
+          if (prevEntry) {
+            assert(prevIsCorrectOrder(prevEntry, entry, query.order));
+          }
+
+          assert(queryInclusionMap.get(query)?.has(b64EntryHash));
+          entriesRead += 1;
+          prevEntry = entry;
+
+          awaiting.delete(b64EntryHash);
+
+          if (query.limit && entriesRead > query.limit) {
+            assert(false, "Too many entries received for query");
+          }
+        }
+
+        if (query.limit) {
+          assertEquals(
+            entriesRead,
+            Math.min(query.limit, queryInclusionMap.get(query)!.size),
+          );
+        } else {
+          assertEquals(entriesRead, queryInclusionMap.get(query)!.size);
+        }
       }
-    }
+    });
+
+    await dispose();
   }
 });
 

--- a/src/replica/storage/storage_3d/triple_storage.ts
+++ b/src/replica/storage/storage_3d/triple_storage.ts
@@ -656,7 +656,7 @@ export class TripleStorage<
         authTokenHash: values.authTokenHash,
       };
 
-      if (entriesYielded === query.limit) {
+      if (query.limit && entriesYielded === query.limit) {
         break;
       }
     }

--- a/src/replica/storage/storage_3d/triple_storage.ts
+++ b/src/replica/storage/storage_3d/triple_storage.ts
@@ -1,0 +1,690 @@
+import { Products } from "../../../../deps.ts";
+import { Entry } from "../../../entries/types.ts";
+import { bigintToBytes } from "../../../util/bytes.ts";
+import {
+  FingerprintScheme,
+  OptionalBounds,
+  PathLengthScheme,
+  PayloadScheme,
+  Query,
+  SubspaceScheme,
+} from "../../types.ts";
+import {
+  decodeEntryKey,
+  decodeSummarisableStorageValue,
+  encodeEntryKeys,
+  encodeSummarisableStorageValue,
+} from "../../util.ts";
+import { LiftingMonoid } from "../summarisable_storage/lifting_monoid.ts";
+import { SummarisableStorage } from "../summarisable_storage/types.ts";
+import { Storage3d } from "./types.ts";
+
+export type TripleStorageOpts<
+  NamespaceKey,
+  SubspaceKey,
+  PayloadDigest,
+  Fingerprint,
+> = {
+  namespace: NamespaceKey;
+  /** Creates a {@link SummarisableStorage} with a given ID, used for storing entries and their data. */
+  createSummarisableStorage: (
+    monoid: LiftingMonoid<Uint8Array, Fingerprint>,
+    id: string,
+  ) => SummarisableStorage<Uint8Array, Fingerprint>;
+  subspaceScheme: SubspaceScheme<SubspaceKey>;
+  payloadScheme: PayloadScheme<PayloadDigest>;
+  pathLengthScheme: PathLengthScheme;
+  fingerprintScheme: FingerprintScheme<
+    NamespaceKey,
+    SubspaceKey,
+    PayloadDigest,
+    Fingerprint
+  >;
+};
+
+export class TripleStorage<
+  NamespaceKey,
+  SubspaceKey,
+  PayloadDigest,
+  Fingerprint,
+> implements
+  Storage3d<
+    NamespaceKey,
+    SubspaceKey,
+    PayloadDigest,
+    Fingerprint
+  > {
+  private namespace: NamespaceKey;
+
+  private ptsStorage: SummarisableStorage<Uint8Array, Fingerprint>;
+  private sptStorage: SummarisableStorage<Uint8Array, Fingerprint>;
+  private tspStorage: SummarisableStorage<Uint8Array, Fingerprint>;
+
+  private subspaceScheme: SubspaceScheme<SubspaceKey>;
+  private payloadScheme: PayloadScheme<PayloadDigest>;
+  private pathLengthScheme: PathLengthScheme;
+  private fingerprintScheme: FingerprintScheme<
+    NamespaceKey,
+    SubspaceKey,
+    PayloadDigest,
+    Fingerprint
+  >;
+
+  constructor(
+    opts: TripleStorageOpts<
+      NamespaceKey,
+      SubspaceKey,
+      PayloadDigest,
+      Fingerprint
+    >,
+  ) {
+    this.namespace = opts.namespace;
+
+    const lift = (
+      key: Uint8Array,
+      value: Uint8Array,
+      order: "path" | "subspace" | "timestamp",
+    ) => {
+      const values = decodeSummarisableStorageValue(
+        value,
+        this.payloadScheme,
+        this.pathLengthScheme,
+      );
+
+      // Decode the key.
+      const { subspace, timestamp, path } = decodeEntryKey(
+        key,
+        order,
+        this.subspaceScheme,
+        values.pathLength,
+      );
+
+      const entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest> = {
+        identifier: {
+          namespace: this.namespace,
+          path,
+          subspace,
+        },
+        record: {
+          timestamp,
+          hash: values.payloadHash,
+          length: values.payloadLength,
+        },
+      };
+
+      return opts.fingerprintScheme.fingerprintSingleton(entry);
+    };
+
+    this.ptsStorage = opts.createSummarisableStorage({
+      lift: (key, value) => lift(key, value, "path"),
+      combine: opts.fingerprintScheme.fingerprintCombine,
+      neutral: opts.fingerprintScheme.neutral,
+    }, "pts");
+    this.sptStorage = opts.createSummarisableStorage({
+      lift: (key, value) => lift(key, value, "subspace"),
+      combine: opts.fingerprintScheme.fingerprintCombine,
+      neutral: opts.fingerprintScheme.neutral,
+    }, "spt");
+    this.tspStorage = opts.createSummarisableStorage({
+      lift: (key, value) => lift(key, value, "timestamp"),
+      combine: opts.fingerprintScheme.fingerprintCombine,
+      neutral: opts.fingerprintScheme.neutral,
+    }, "tsp");
+
+    this.subspaceScheme = opts.subspaceScheme;
+    this.payloadScheme = opts.payloadScheme;
+    this.pathLengthScheme = opts.pathLengthScheme;
+
+    this.fingerprintScheme = opts.fingerprintScheme;
+  }
+
+  async get(
+    subspace: SubspaceKey,
+    path: Uint8Array,
+  ): Promise<
+    {
+      entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest>;
+      authTokenHash: PayloadDigest;
+    } | undefined
+  > {
+    const firstResult = this.entriesByQuery({
+      subspace: {
+        lowerBound: subspace,
+        upperBound: this.subspaceScheme.successor(subspace),
+      },
+      path: {
+        lowerBound: path,
+        upperBound: Products.makeSuccessorPath(this.pathLengthScheme.maxLength)(
+          path,
+        ),
+      },
+      limit: 1,
+      order: "subspace",
+    });
+
+    for await (const result of firstResult) {
+      return result;
+    }
+  }
+
+  async insert(
+    { path, subspace, payloadHash, timestamp, length, authTokenHash }: {
+      path: Uint8Array;
+      subspace: SubspaceKey;
+      payloadHash: PayloadDigest;
+      timestamp: bigint;
+      length: bigint;
+      authTokenHash: PayloadDigest;
+    },
+  ): Promise<void> {
+    const keys = encodeEntryKeys(
+      {
+        path,
+        timestamp,
+        subspace,
+        subspaceEncoding: this.subspaceScheme,
+      },
+    );
+
+    const toStore = encodeSummarisableStorageValue(
+      {
+        payloadHash,
+        payloadLength: length,
+        authTokenHash: authTokenHash,
+        payloadScheme: this.payloadScheme,
+        pathLength: path.byteLength,
+        pathLengthEncoding: this.pathLengthScheme,
+      },
+    );
+
+    await Promise.all([
+      this.ptsStorage.insert(keys.pts, toStore),
+      this.sptStorage.insert(keys.spt, toStore),
+      this.tspStorage.insert(keys.tsp, toStore),
+    ]);
+  }
+
+  async remove(
+    entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest>,
+  ): Promise<boolean> {
+    const keys = encodeEntryKeys(
+      {
+        path: entry.identifier.path,
+        timestamp: entry.record.timestamp,
+        subspace: entry.identifier.subspace,
+        subspaceEncoding: this.subspaceScheme,
+      },
+    );
+
+    const results = await Promise.all([
+      this.ptsStorage.remove(keys.pts),
+      this.tspStorage.remove(keys.tsp),
+      this.sptStorage.remove(keys.spt),
+    ]);
+
+    return results[0];
+  }
+
+  async summarise(
+    product: Products.CanonicProduct<SubspaceKey>,
+    countLimit?: number | undefined,
+    sizeLimit?: bigint | undefined,
+  ): Promise<{ fingerprint: Fingerprint; size: number }> {
+    // Okay. How do I create a fingerprint from three summarisable storages?
+
+    const [subspaceDisjoint, pathDisjoint, timeDisjoint] = product;
+
+    let fingerprint = this.fingerprintScheme.neutral;
+    let size = 0;
+
+    for (const subspaceRange of subspaceDisjoint) {
+      const subspaceEntriesLowerBound = subspaceRange.start;
+      const subspaceEntriesUpperBound = subspaceRange.kind === "open"
+        ? undefined
+        : subspaceRange.kind === "closed_exclusive"
+        ? subspaceRange.end
+        : this.subspaceScheme.successor(subspaceRange.end);
+
+      const subspaceEntries = this.sptStorage.entries(
+        this.subspaceScheme.encode(subspaceEntriesLowerBound),
+        subspaceEntriesUpperBound
+          ? this.subspaceScheme.encode(subspaceEntriesUpperBound)
+          : undefined,
+      );
+
+      let payloadLimitUsed = BigInt(0);
+      let countLimitUsed = 0;
+
+      const qualifyingEntries: [
+        Uint8Array | undefined,
+        Uint8Array | undefined,
+      ] = [undefined, undefined];
+
+      const updateQualifyingEntries = (key: Uint8Array) => {
+        if (qualifyingEntries[0] === undefined) {
+          qualifyingEntries[0] = key;
+        } else {
+          qualifyingEntries[1] = key;
+        }
+      };
+
+      const updateFingerprint = async () => {
+        const [fst, last] = qualifyingEntries;
+
+        if (!fst) {
+          return;
+        }
+
+        const { fingerprint: includedFp, size: includedSize } = await this
+          .sptStorage.summarise(
+            fst,
+            last ? last : new Uint8Array(),
+          );
+
+        fingerprint = this.fingerprintScheme.fingerprintCombine(
+          fingerprint,
+          includedFp,
+        );
+        size += includedSize;
+
+        qualifyingEntries[0] = undefined;
+        qualifyingEntries[1] = undefined;
+
+        return;
+      };
+
+      for await (const subspaceEntry of subspaceEntries) {
+        // Decode the key.
+        const values = decodeSummarisableStorageValue(
+          subspaceEntry.value,
+          this.payloadScheme,
+          this.pathLengthScheme,
+        );
+
+        // Decode the key.
+        const { timestamp, path } = decodeEntryKey(
+          subspaceEntry.key,
+          "path",
+          this.subspaceScheme,
+          values.pathLength,
+        );
+
+        // Check that decoded time and subspace are included by both other dimensions
+        let pathIncluded = false;
+
+        for (const range of pathDisjoint) {
+          if (
+            Products.rangeIncludesValue(
+              { order: Products.orderPaths },
+              range,
+              path,
+            )
+          ) {
+            pathIncluded = true;
+            break;
+          }
+        }
+
+        if (!pathIncluded) {
+          // Update the fingerprint using the last accepted thing, if there.
+          await updateFingerprint();
+
+          continue;
+        }
+
+        let timeIncluded = false;
+
+        for (const range of timeDisjoint) {
+          if (
+            Products.rangeIncludesValue(
+              { order: Products.orderTimestamps },
+              range,
+              timestamp,
+            )
+          ) {
+            timeIncluded = true;
+            break;
+          }
+        }
+
+        if (!timeIncluded) {
+          // Update fingerprint using last updated thing, if there
+
+          await updateFingerprint();
+
+          continue;
+        }
+
+        payloadLimitUsed += values.payloadLength;
+
+        if (sizeLimit && payloadLimitUsed > sizeLimit) {
+          break;
+        }
+
+        countLimitUsed += 1;
+
+        if (countLimit && countLimitUsed > countLimit) {
+          break;
+        }
+
+        updateQualifyingEntries(subspaceEntry.key);
+      }
+
+      await updateFingerprint();
+    }
+
+    return {
+      fingerprint,
+      size,
+    };
+  }
+
+  async *entriesByProduct(
+    product: Products.CanonicProduct<SubspaceKey>,
+    countLimit?: number | undefined,
+    sizeLimit?: bigint | undefined,
+  ): AsyncIterable<{
+    entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest>;
+    authTokenHash: PayloadDigest;
+  }> {
+    const [subspaceDisjoint, pathDisjoint, timeDisjoint] = product;
+
+    if (
+      subspaceDisjoint.length === 0 && pathDisjoint.length === 0 &&
+      timeDisjoint.length === 0
+    ) {
+      //empty product
+      return;
+    }
+
+    let payloadLimitUsed = BigInt(0);
+    let countLimitUsed = 0;
+
+    // Iterate over each interval in the path disjoint.
+    for (const interval of pathDisjoint) {
+      const iter = interval.kind === "closed_exclusive"
+        ? this.ptsStorage.entries(interval.start, interval.end)
+        : this.ptsStorage.entries(interval.start, undefined);
+
+      for await (const { key, value } of iter) {
+        const values = decodeSummarisableStorageValue(
+          value,
+          this.payloadScheme,
+          this.pathLengthScheme,
+        );
+
+        // Decode the key.
+        const { subspace, timestamp, path } = decodeEntryKey(
+          key,
+          "path",
+          this.subspaceScheme,
+          values.pathLength,
+        );
+
+        // Check that decoded time and subspace are included by both other dimensions
+        let subspaceIncluded = false;
+
+        for (const range of subspaceDisjoint) {
+          if (
+            Products.rangeIncludesValue(
+              { order: this.subspaceScheme.order },
+              range,
+              subspace,
+            )
+          ) {
+            subspaceIncluded = true;
+            break;
+          }
+        }
+
+        if (!subspaceIncluded) {
+          continue;
+        }
+
+        let timeIncluded = false;
+
+        for (const range of timeDisjoint) {
+          if (
+            Products.rangeIncludesValue(
+              { order: Products.orderTimestamps },
+              range,
+              timestamp,
+            )
+          ) {
+            timeIncluded = true;
+            break;
+          }
+        }
+
+        if (!timeIncluded) {
+          continue;
+        }
+
+        payloadLimitUsed += values.payloadLength;
+
+        if (sizeLimit && payloadLimitUsed > sizeLimit) {
+          break;
+        }
+
+        countLimitUsed += 1;
+
+        if (countLimit && countLimitUsed > countLimit) {
+          break;
+        }
+
+        yield {
+          entry: {
+            identifier: {
+              namespace: this.namespace,
+              subspace,
+              path,
+            },
+            record: {
+              hash: values.payloadHash,
+              length: values.payloadLength,
+              timestamp,
+            },
+          },
+          authTokenHash: values.authTokenHash,
+        };
+      }
+    }
+  }
+
+  async *entriesByQuery(
+    query: Query<SubspaceKey>,
+  ): AsyncIterable<{
+    entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest>;
+    authTokenHash: PayloadDigest;
+  }> {
+    const storage = query.order === "subspace"
+      ? this.sptStorage
+      : query.order === "path"
+      ? this.ptsStorage
+      : this.tspStorage;
+
+    if (!query.subspace && !query.path && !query.time) {
+      const allEntriesOnOrder = storage.entries(undefined, undefined, {
+        limit: query.limit,
+        reverse: query.reverse,
+      });
+
+      for await (const { key, value } of allEntriesOnOrder) {
+        const values = decodeSummarisableStorageValue(
+          value,
+          this.payloadScheme,
+          this.pathLengthScheme,
+        );
+
+        // Decode the key.
+        const { subspace, timestamp, path } = decodeEntryKey(
+          key,
+          query.order,
+          this.subspaceScheme,
+          values.pathLength,
+        );
+
+        yield {
+          entry: {
+            identifier: {
+              namespace: this.namespace,
+              subspace,
+              path,
+            },
+            record: {
+              hash: values.payloadHash,
+              length: values.payloadLength,
+              timestamp,
+            },
+          },
+          authTokenHash: values.authTokenHash,
+        };
+      }
+
+      return;
+    }
+
+    let lowerBound: Uint8Array | undefined;
+    let upperBound: Uint8Array | undefined;
+
+    const leastPath = new Uint8Array();
+
+    if (query.order === "path" && query.path) {
+      lowerBound = query.path.lowerBound;
+      upperBound = query.path.upperBound;
+    } else if (query.order === "subspace" && query.subspace) {
+      lowerBound = query.subspace.lowerBound
+        ? this.subspaceScheme.encode(query.subspace.lowerBound)
+        : undefined;
+      upperBound = query.subspace.upperBound
+        ? this.subspaceScheme.encode(query.subspace.upperBound)
+        : undefined;
+    } else if (query.order === "timestamp" && query.time) {
+      lowerBound = query.time.lowerBound
+        ? bigintToBytes(query.time.lowerBound)
+        : undefined;
+      upperBound = query.time.upperBound
+        ? bigintToBytes(query.time.upperBound)
+        : undefined;
+    }
+
+    let entriesYielded = 0;
+
+    const iterator = storage.entries(lowerBound, upperBound, {
+      reverse: query.reverse,
+    });
+
+    for await (const { key, value } of iterator) {
+      const values = decodeSummarisableStorageValue(
+        value,
+        this.payloadScheme,
+        this.pathLengthScheme,
+      );
+
+      // Decode the key.
+      const { subspace, timestamp, path } = decodeEntryKey(
+        key,
+        query.order,
+        this.subspaceScheme,
+        values.pathLength,
+      );
+
+      if (
+        (query.order === "path" || query.order === "timestamp") &&
+        query.subspace
+      ) {
+        const isIncludedInSubspaceRange = Products.rangeIncludesValue(
+          {
+            order: this.subspaceScheme.order,
+          },
+          rangeFromOptionalBounds(
+            query.subspace,
+            this.subspaceScheme.minimalSubspaceKey,
+          ),
+          subspace,
+        );
+
+        if (!isIncludedInSubspaceRange) {
+          continue;
+        }
+      }
+
+      if (
+        (query.order === "path" || query.order === "subspace") && query.time
+      ) {
+        const isIncluded = Products.rangeIncludesValue(
+          { order: Products.orderTimestamps },
+          rangeFromOptionalBounds(query.time, BigInt(0)),
+          timestamp,
+        );
+
+        if (!isIncluded) {
+          continue;
+        }
+      }
+
+      if (
+        (query.order === "subspace" || query.order === "timestamp") &&
+        query.path
+      ) {
+        const isIncludedInPathRange = Products.rangeIncludesValue(
+          { order: Products.orderPaths },
+          rangeFromOptionalBounds(query.path, leastPath),
+          path,
+        );
+
+        if (!isIncludedInPathRange) {
+          continue;
+        }
+      }
+
+      entriesYielded += 1;
+
+      yield {
+        entry: {
+          identifier: {
+            namespace: this.namespace,
+            subspace,
+            path,
+          },
+          record: {
+            hash: values.payloadHash,
+            length: values.payloadLength,
+            timestamp,
+          },
+        },
+        authTokenHash: values.authTokenHash,
+      };
+
+      if (entriesYielded === query.limit) {
+        break;
+      }
+    }
+  }
+}
+
+function rangeFromOptionalBounds<ValueType>(
+  bounds: OptionalBounds<ValueType>,
+  leastValue: ValueType,
+): Products.Range<ValueType> {
+  if (bounds.lowerBound && !bounds.upperBound) {
+    return {
+      kind: "open",
+      start: bounds.lowerBound,
+    };
+  }
+
+  if (bounds.upperBound && !bounds.lowerBound) {
+    return {
+      kind: "closed_exclusive",
+      start: leastValue,
+      end: bounds.upperBound,
+    };
+  }
+
+  return {
+    kind: "closed_exclusive",
+    start: bounds.lowerBound!,
+    end: bounds.upperBound!,
+  };
+}

--- a/src/replica/storage/storage_3d/types.ts
+++ b/src/replica/storage/storage_3d/types.ts
@@ -35,8 +35,8 @@ export interface Storage3d<
   // Used during sync
   summarise(
     product: Products.CanonicProduct<SubspaceKey>,
-    countLimit?: number,
-    sizeLimit?: bigint,
+    countLimits?: { subspace?: number; path?: number; time?: number },
+    sizeLimits?: { subspace?: bigint; path?: bigint; time?: bigint },
   ): Promise<{ fingerprint: Fingerprint; size: number }>;
 
   // Used to fetch entries for transfer during sync.

--- a/src/replica/storage/storage_3d/types.ts
+++ b/src/replica/storage/storage_3d/types.ts
@@ -43,8 +43,8 @@ export interface Storage3d<
   // All three dimensions are defined
   entriesByProduct(
     product: Products.CanonicProduct<SubspaceKey>,
-    countLimit?: number,
-    sizeLimit?: bigint,
+    countLimits?: { subspace?: number; path?: number; time?: number },
+    sizeLimits?: { subspace?: bigint; path?: bigint; time?: bigint },
   ): AsyncIterable<
     {
       entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest>;

--- a/src/replica/storage/storage_3d/types.ts
+++ b/src/replica/storage/storage_3d/types.ts
@@ -1,0 +1,65 @@
+import { Products } from "../../../../deps.ts";
+import { Entry } from "../../../entries/types.ts";
+import { Query } from "../../types.ts";
+
+export interface Storage3d<
+  NamespaceKey,
+  SubspaceKey,
+  PayloadDigest,
+  Fingerprint,
+> {
+  /** Retrieve a value */
+  get(
+    subspace: SubspaceKey,
+    path: Uint8Array,
+  ): Promise<
+    {
+      entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest>;
+      authTokenHash: PayloadDigest;
+    } | undefined
+  >;
+
+  insert(opts: {
+    path: Uint8Array;
+    subspace: SubspaceKey;
+    payloadHash: PayloadDigest;
+    timestamp: bigint;
+    length: bigint;
+    authTokenHash: PayloadDigest;
+  }): Promise<void>;
+
+  remove(
+    entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest>,
+  ): Promise<boolean>;
+
+  // Used during sync
+  summarise(
+    product: Products.CanonicProduct<SubspaceKey>,
+    countLimit?: number,
+    sizeLimit?: bigint,
+  ): Promise<{ fingerprint: Fingerprint; size: number }>;
+
+  // Used to fetch entries for transfer during sync.
+  // All three dimensions are defined
+  entriesByProduct(
+    product: Products.CanonicProduct<SubspaceKey>,
+    countLimit?: number,
+    sizeLimit?: bigint,
+  ): AsyncIterable<
+    {
+      entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest>;
+      authTokenHash: PayloadDigest;
+    }
+  >;
+
+  // Used to fetch entries when user is making query through replica
+  // 0 - 3 dimensions may be defined
+  entriesByQuery(
+    query: Query<SubspaceKey>,
+  ): AsyncIterable<
+    {
+      entry: Entry<NamespaceKey, SubspaceKey, PayloadDigest>;
+      authTokenHash: PayloadDigest;
+    }
+  >;
+}

--- a/src/replica/storage/summarisable_storage/lifting_monoid.ts
+++ b/src/replica/storage/summarisable_storage/lifting_monoid.ts
@@ -1,5 +1,5 @@
-export type LiftingMonoid<ValueType, LiftedType> = {
-  lift: (i: ValueType) => Promise<LiftedType>;
+export type LiftingMonoid<KeyType, LiftedType> = {
+  lift: (key: KeyType, value: Uint8Array) => Promise<LiftedType>;
   combine: (
     a: LiftedType,
     b: LiftedType,
@@ -13,8 +13,8 @@ export function combineMonoid<V, AL, BL>(
   b: LiftingMonoid<V, BL>,
 ): LiftingMonoid<V, [AL, BL]> {
   return {
-    lift: async (i) => {
-      return [await a.lift(i), await b.lift(i)];
+    lift: async (i, j) => {
+      return [await a.lift(i, j), await b.lift(i, j)];
     },
     combine: (ia, ib) => {
       const fst = a.combine(ia[0], ib[0]);
@@ -26,35 +26,9 @@ export function combineMonoid<V, AL, BL>(
   };
 }
 
-/** A monoid which lifts the member as a string, and combines by concatenating together. */
-export const concatMonoid: LiftingMonoid<string, string> = {
-  lift: (a: string) => Promise.resolve(a),
-  combine: (a: string, b: string) => {
-    return a + b;
-  },
-  neutral: "",
-};
-
 /** A monoid which lifts the member as 1, and combines by adding together. */
 export const sizeMonoid: LiftingMonoid<unknown, number> = {
   lift: (_a: unknown) => Promise.resolve(1),
   combine: (a: number, b: number) => a + b,
   neutral: 0,
-};
-
-/** A monoid which lifts using SHA-256, and combines the resulting hash using a bitwise XOR.*/
-export const sha256XorMonoid: LiftingMonoid<Uint8Array, Uint8Array> = {
-  lift: async (v: Uint8Array) => {
-    return new Uint8Array(await crypto.subtle.digest("SHA-256", v));
-  },
-  combine: (a: Uint8Array, b: Uint8Array) => {
-    const xored = [];
-
-    for (let i = 0; i < a.length; i++) {
-      xored.push(a[i] ^ b[i]);
-    }
-
-    return new Uint8Array(xored);
-  },
-  neutral: new Uint8Array(8),
 };

--- a/src/replica/storage/summarisable_storage/monoid_rbtree.ts
+++ b/src/replica/storage/summarisable_storage/monoid_rbtree.ts
@@ -3,9 +3,10 @@ import {
   Direction,
   RedBlackNode,
 } from "https://deno.land/std@0.188.0/collections/red_black_node.ts";
-import { deferred } from "$std/async/deferred.ts";
+
 import { combineMonoid, LiftingMonoid, sizeMonoid } from "./lifting_monoid.ts";
 import { SummarisableStorage } from "./types.ts";
+import { deferred } from "../../../../deps.ts";
 
 const debug = false;
 
@@ -24,26 +25,33 @@ class MonoidTreeNode<
   isReady = deferred();
 
   private monoid: LiftingMonoid<ValueType, LiftType>;
+  private valueMapping: Map<ValueType, Uint8Array>;
 
   constructor(
     parent: MonoidTreeNode<ValueType, LiftType> | null,
     value: ValueType,
     monoid: LiftingMonoid<ValueType, LiftType>,
+    valueMapping: Map<ValueType, Uint8Array>,
   ) {
     super(parent, value);
 
     this.label = monoid.neutral;
     this.liftedValue = monoid.neutral;
     this.monoid = monoid;
+    this.valueMapping = valueMapping;
 
-    this.monoid.lift(value).then((liftedValue) => {
+    const data = valueMapping.get(value) as Uint8Array;
+
+    this.monoid.lift(value, data).then((liftedValue) => {
       this.liftedValue = liftedValue;
       this.isReady.resolve();
     });
   }
 
   async updateLiftedValue() {
-    this.liftedValue = await this.monoid.lift(this.value);
+    const data = this.valueMapping.get(this.value) as Uint8Array;
+
+    this.liftedValue = await this.monoid.lift(this.value, data);
 
     this.updateLabel(true, "updated lifted value");
   }
@@ -115,13 +123,18 @@ class RbTreeBase<ValueType, LiftedType> extends RedBlackTree<ValueType> {
 
   private cachedMinNode: NodeType<ValueType, LiftedType> | null = null;
 
+  private valueMapping: Map<ValueType, Uint8Array>;
+
   constructor(
     /** The lifting monoid which is used to label nodes and derive fingerprints from ranges. */
     monoid: LiftingMonoid<ValueType, LiftedType>,
     /** A function to sort values by. Will use JavaScript's default comparison if not provided. */
     compare: (a: ValueType, b: ValueType) => number,
+    valueMapping: Map<ValueType, Uint8Array>,
   ) {
     super(compare);
+
+    this.valueMapping = valueMapping;
 
     const maxMonoid = {
       lift: (v: ValueType) => Promise.resolve(v),
@@ -143,7 +156,7 @@ class RbTreeBase<ValueType, LiftedType> extends RedBlackTree<ValueType> {
 
         return compare(a, b) > 0 ? a : b;
       },
-      neutral: undefined,
+      neutral: undefined as ValueType,
     } as LiftingMonoid<ValueType, ValueType>;
 
     this.monoid = combineMonoid(
@@ -294,7 +307,12 @@ class RbTreeBase<ValueType, LiftedType> extends RedBlackTree<ValueType> {
     value: ValueType,
   ): Promise<NodeType<ValueType, LiftedType> | null> {
     if (!this.root) {
-      const newNode = new MonoidTreeNode(null, value, this.monoid);
+      const newNode = new MonoidTreeNode(
+        null,
+        value,
+        this.monoid,
+        this.valueMapping,
+      );
       await newNode.isReady;
       this.root = newNode;
       this._size++;
@@ -322,7 +340,12 @@ class RbTreeBase<ValueType, LiftedType> extends RedBlackTree<ValueType> {
         if (node[direction]) {
           node = node[direction]!;
         } else {
-          const newNode = new MonoidTreeNode(node, value, this.monoid);
+          const newNode = new MonoidTreeNode(
+            node,
+            value,
+            this.monoid,
+            this.valueMapping,
+          );
           await newNode.isReady;
           node[direction] = newNode;
           this._size++;
@@ -449,6 +472,8 @@ class RbTreeBase<ValueType, LiftedType> extends RedBlackTree<ValueType> {
       return false;
     }
 
+    this.valueMapping.delete(value);
+
     const removedNode = await this.removeMonoidNode(node) as (
       | NodeType<ValueType, LiftedType>
       | null
@@ -531,7 +556,10 @@ class RbTreeBase<ValueType, LiftedType> extends RedBlackTree<ValueType> {
           y,
         );
 
-        const maxLifted = await this.monoid.lift(maxValue);
+        const maxLifted = await this.monoid.lift(
+          maxValue,
+          this.valueMapping.get(maxValue) as Uint8Array,
+        );
 
         const synthesisedLabel = [maxLifted[0], [1, maxValue]] as CombinedLabel<
           ValueType,
@@ -568,7 +596,10 @@ class RbTreeBase<ValueType, LiftedType> extends RedBlackTree<ValueType> {
         );
 
         if (this.compare(x, maxValue) === 0) {
-          const maxLifted = await this.monoid.lift(maxValue);
+          const maxLifted = await this.monoid.lift(
+            maxValue,
+            this.valueMapping.get(maxValue) as Uint8Array,
+          );
 
           const synthesisedLabel = [maxLifted[0], [
             1,
@@ -607,7 +638,10 @@ class RbTreeBase<ValueType, LiftedType> extends RedBlackTree<ValueType> {
           maxValue,
         );
 
-        const maxLifted = await this.monoid.lift(maxValue);
+        const maxLifted = await this.monoid.lift(
+          maxValue,
+          this.valueMapping.get(maxValue) as Uint8Array,
+        );
 
         const synthesisedLabel = [maxLifted[0], [1, maxValue]] as CombinedLabel<
           ValueType,
@@ -966,7 +1000,7 @@ export class MonoidRbTree<ValueType, LiftedType>
   private valueMapping = new Map<ValueType, Uint8Array>();
 
   constructor(opts: MonoidRbTreeOpts<ValueType, LiftedType>) {
-    this.tree = new RbTreeBase(opts.monoid, opts.compare);
+    this.tree = new RbTreeBase(opts.monoid, opts.compare, this.valueMapping);
   }
 
   get(key: ValueType): Promise<Uint8Array | undefined> {
@@ -980,8 +1014,8 @@ export class MonoidRbTree<ValueType, LiftedType>
   }
 
   async insert(key: ValueType, value: Uint8Array): Promise<void> {
-    await this.tree.insertMonoid(key);
     this.valueMapping.set(key, value);
+    await this.tree.insertMonoid(key);
   }
 
   async summarise(

--- a/src/replica/storage/summarisable_storage/monoid_skiplist.ts
+++ b/src/replica/storage/summarisable_storage/monoid_skiplist.ts
@@ -1,5 +1,5 @@
-import { deferred } from "$std/async/deferred.ts";
-import { Key, KeyPart, KvDriver } from "../kv/types.ts";
+import { deferred } from "../../../../deps.ts";
+import { KeyPart, KvDriver } from "../kv/types.ts";
 import { combineMonoid, LiftingMonoid, sizeMonoid } from "./lifting_monoid.ts";
 import { SummarisableStorage } from "./types.ts";
 
@@ -169,13 +169,13 @@ export class Skiplist<
       undefined;
     let previousComputedLabel: [LiftedType, number] | undefined = undefined;
 
-    const liftedValue = await this.monoid.lift(key);
+    const liftedValue = await this.monoid.lift(key, value);
 
     for (let layer = 0; layer <= insertionHeight; layer++) {
       // On the first layer we don't need to compute any labels, as there is no skipping.
       // But unlike higher layeys, we DO need to store the payload hash.
       if (layer === 0) {
-        const label = await this.monoid.lift(key);
+        const label = await this.monoid.lift(key, value);
 
         previousComputedLabel = label;
 

--- a/src/replica/storage/summarisable_storage/simple_kv.ts
+++ b/src/replica/storage/summarisable_storage/simple_kv.ts
@@ -194,7 +194,7 @@ export class SimpleKv<ValueType extends KeyPart, LiftedType>
     let size = 0;
 
     for await (const entry of this.entries(start, end)) {
-      const lifted = await this.monoid.lift(entry.key);
+      const lifted = await this.monoid.lift(entry.key, entry.value);
 
       fingerprint = this.monoid.combine(fingerprint, lifted);
       size += 1;

--- a/src/replica/util.ts
+++ b/src/replica/util.ts
@@ -150,11 +150,13 @@ export function decodeEntryKey<SubspacePublicKey>(
         0,
       );
 
-      path = encoded.subarray(8, 8 + pathLength);
-
       subspace = subspaceEncoding.decode(
-        encoded.subarray(8 + pathLength),
+        encoded.subarray(8),
       );
+
+      const encodedSubspaceLength = subspaceEncoding.encodedLength(subspace);
+
+      path = encoded.subarray(8 + encodedSubspaceLength);
     }
   }
 

--- a/src/replica/util.ts
+++ b/src/replica/util.ts
@@ -1,10 +1,11 @@
 import { join } from "https://deno.land/std@0.188.0/path/mod.ts";
 import { EntryDriverKvStore } from "./storage/entry_drivers/kv_store.ts";
 import { PayloadDriverFilesystem } from "./storage/payload_drivers/filesystem.ts";
-import { EncodingScheme, ProtocolParameters } from "./types.ts";
+import { EncodingScheme, PayloadScheme, ProtocolParameters } from "./types.ts";
 import { ensureDir } from "https://deno.land/std@0.188.0/fs/ensure_dir.ts";
 import { bigintToBytes } from "../util/bytes.ts";
-import { concat } from "$std/bytes/concat.ts";
+import { concat } from "../../deps.ts";
+import { KvDriverDeno } from "./storage/kv/kv_driver_deno.ts";
 
 /** Create a pair of entry and payload drivers for use with a {@link Replica} which will store their data at a given filesystem path. */
 export async function getPersistedDrivers<
@@ -13,6 +14,7 @@ export async function getPersistedDrivers<
   PayloadDigest,
   AuthorisationOpts,
   AuthorisationToken,
+  Fingerprint,
 >(
   /** The filesystem path to store entry and payload data within. */
   path: string,
@@ -21,7 +23,8 @@ export async function getPersistedDrivers<
     SubspacePublicKey,
     PayloadDigest,
     AuthorisationOpts,
-    AuthorisationToken
+    AuthorisationToken,
+    Fingerprint
   >,
 ) {
   const kvPath = join(path, "entries");
@@ -29,10 +32,14 @@ export async function getPersistedDrivers<
 
   await ensureDir(path);
 
+  // TODO: Use the platform appropriate KV driver.
   const kv = await Deno.openKv(kvPath);
 
   return {
-    entryDriver: new EntryDriverKvStore(kv),
+    entryDriver: new EntryDriverKvStore({
+      ...protocolParameters,
+      kvDriver: new KvDriverDeno(kv),
+    }),
     payloadDriver: new PayloadDriverFilesystem(
       payloadPath,
       protocolParameters.payloadScheme,
@@ -163,14 +170,14 @@ export function encodeSummarisableStorageValue<PayloadDigest>(
     authTokenHash,
     payloadHash,
     payloadLength,
-    payloadEncoding,
+    payloadScheme,
     pathLength,
     pathLengthEncoding,
   }: {
     authTokenHash: PayloadDigest;
     payloadHash: PayloadDigest;
     payloadLength: bigint;
-    payloadEncoding: EncodingScheme<PayloadDigest>;
+    payloadScheme: PayloadScheme<PayloadDigest>;
     pathLength: number;
     pathLengthEncoding: EncodingScheme<number>;
   },
@@ -178,8 +185,8 @@ export function encodeSummarisableStorageValue<PayloadDigest>(
   return concat(
     pathLengthEncoding.encode(pathLength),
     bigintToBytes(payloadLength),
-    payloadEncoding.encode(payloadHash),
-    payloadEncoding.encode(authTokenHash),
+    payloadScheme.encode(payloadHash),
+    payloadScheme.encode(authTokenHash),
   );
 }
 

--- a/src/test/crypto.ts
+++ b/src/test/crypto.ts
@@ -1,0 +1,48 @@
+export async function makeNamespaceKeypair() {
+  const { publicKey, privateKey } = await crypto.subtle.generateKey(
+    {
+      name: "ECDSA",
+      namedCurve: "P-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+
+  return {
+    namespace: new Uint8Array(
+      await window.crypto.subtle.exportKey("raw", publicKey),
+    ),
+    privateKey,
+  };
+}
+
+export async function makeSubspaceKeypair() {
+  const { publicKey, privateKey } = await crypto.subtle.generateKey(
+    {
+      name: "ECDSA",
+      namedCurve: "P-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+
+  return {
+    subspace: new Uint8Array(
+      await window.crypto.subtle.exportKey("raw", publicKey),
+    ),
+    privateKey,
+  };
+}
+
+export function importPublicKey(raw: ArrayBuffer) {
+  return crypto.subtle.importKey(
+    "raw",
+    raw,
+    {
+      name: "ECDSA",
+      namedCurve: "P-256",
+    },
+    true,
+    ["verify"],
+  );
+}

--- a/src/test/test_schemes.ts
+++ b/src/test/test_schemes.ts
@@ -1,0 +1,145 @@
+import { equalsBytes, Products } from "../../deps.ts";
+import { crypto } from "https://deno.land/std@0.188.0/crypto/crypto.ts";
+import { encodeEntry } from "../entries/encode_decode.ts";
+import {
+  AuthorisationScheme,
+  FingerprintScheme,
+  NamespaceScheme,
+  PathLengthScheme,
+  PayloadScheme,
+  SubspaceScheme,
+} from "../replica/types.ts";
+import { compareBytes } from "../util/bytes.ts";
+import { importPublicKey } from "./crypto.ts";
+
+export const testSchemeNamespace: NamespaceScheme<Uint8Array> = {
+  encode: (v) => v,
+  decode: (v) => v,
+  encodedLength: (v) => v.byteLength,
+  isEqual: equalsBytes,
+};
+
+export const testSchemeSubspace: SubspaceScheme<Uint8Array> = {
+  encode: (v) => v,
+  decode: (v) => v.subarray(0, 65),
+  encodedLength: () => 65,
+  isEqual: equalsBytes,
+  minimalSubspaceKey: new Uint8Array(65),
+  order: Products.orderPaths,
+  successor: Products.makeSuccessorPath(65),
+};
+
+export const testSchemePathLength: PathLengthScheme = {
+  encode(length) {
+    return new Uint8Array([length]);
+  },
+  decode(bytes) {
+    return bytes[0];
+  },
+  encodedLength() {
+    return 1;
+  },
+  maxLength: 8,
+};
+
+export const testSchemePayload: PayloadScheme<ArrayBuffer> = {
+  encode(hash) {
+    return new Uint8Array(hash);
+  },
+  decode(bytes) {
+    return bytes.subarray(0, 32);
+  },
+  encodedLength() {
+    return 32;
+  },
+  async fromBytes(bytes) {
+    return new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+  },
+  order(a, b) {
+    return compareBytes(new Uint8Array(a), new Uint8Array(b)) as
+      | 1
+      | 0
+      | -1;
+  },
+};
+
+export const testSchemeFingerprint: FingerprintScheme<
+  Uint8Array,
+  Uint8Array,
+  Uint8Array,
+  Uint8Array
+> = {
+  neutral: new Uint8Array(32),
+  async fingerprintSingleton(entry) {
+    const encodedEntry = encodeEntry(entry, {
+      namespaceScheme: testSchemeNamespace,
+      subspaceScheme: testSchemeSubspace,
+      pathLengthScheme: testSchemePathLength,
+      payloadScheme: testSchemePayload,
+    });
+
+    return new Uint8Array(await crypto.subtle.digest("SHA-256", encodedEntry));
+  },
+  fingerprintCombine(a, b) {
+    const bytes = new Uint8Array(32);
+
+    for (let i = 0; i < 32; i++) {
+      bytes.set([a[i] ^ b[i]], i);
+    }
+
+    return bytes;
+  },
+};
+
+export const testSchemeAuthorisation: AuthorisationScheme<
+  Uint8Array,
+  Uint8Array,
+  ArrayBuffer,
+  CryptoKey,
+  ArrayBuffer
+> = {
+  async authorise(entry, secretKey) {
+    const encodedEntry = encodeEntry(entry, {
+      namespaceScheme: testSchemeNamespace,
+      subspaceScheme: testSchemeSubspace,
+      pathLengthScheme: testSchemePathLength,
+      payloadScheme: testSchemePayload,
+    });
+
+    const res = await crypto.subtle.sign(
+      {
+        name: "ECDSA",
+        hash: { name: "SHA-256" },
+      },
+      secretKey,
+      encodedEntry,
+    );
+
+    return new Uint8Array(res);
+  },
+  async isAuthorised(entry, token) {
+    const cryptoKey = await importPublicKey(entry.identifier.subspace);
+
+    const encodedEntry = encodeEntry(entry, {
+      namespaceScheme: testSchemeNamespace,
+      subspaceScheme: testSchemeSubspace,
+      pathLengthScheme: testSchemePathLength,
+      payloadScheme: testSchemePayload,
+    });
+
+    return crypto.subtle.verify(
+      {
+        name: "ECDSA",
+        hash: { name: "SHA-256" },
+      },
+      cryptoKey,
+      token,
+      encodedEntry,
+    );
+  },
+  tokenEncoding: {
+    encode: (ab) => new Uint8Array(ab),
+    decode: (bytes) => bytes.buffer,
+    encodedLength: (ab) => ab.byteLength,
+  },
+};

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,0 +1,17 @@
+import { makeSubspaceKeypair } from "./crypto.ts";
+
+export async function getSubspaces(size: number) {
+  const subspaces = [];
+
+  for (let i = 0; i < size; i++) {
+    const keypair = await makeSubspaceKeypair();
+
+    subspaces.push(keypair);
+  }
+
+  return subspaces;
+}
+
+export function randomTimestamp() {
+  return BigInt(Math.floor(Math.random() * 1000));
+}

--- a/src/util/bytes.ts
+++ b/src/util/bytes.ts
@@ -1,4 +1,4 @@
-export function compareBytes(a: Uint8Array, b: Uint8Array): number {
+export function compareBytes(a: Uint8Array, b: Uint8Array): -1 | 0 | 1 {
   const shorter = a.byteLength < b.byteLength ? a : b;
 
   for (let i = 0; i < shorter.byteLength; i++) {


### PR DESCRIPTION
- Replica can now query entries with constraints along all three dimensions (subspace, path, time).
- Introduces `Storage3d`, a new interface accessed by Replica. Replica no longer assumes direct usage of `SummarisableStorage` and has no notion of how things should be stored, or reconstructed from storage. This class also adds methods which we'll need for syncing, such as creating a fingerprint and querying entries with a 3d product. This should make life easier when we want to introduce new, better storage implementations that don't rely on storing the same data three times.
- Improves the passing of protocol parameters, and introduces a `fingerprintScheme` parameter.
- SummarisableStorage's `LiftingMonoid` type now creates fingeprints from a kv pair's key _and_ value, rather than just the key.


