### PR TITLE
Add WgpsMessenger able to conclude commitment scheme

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,7 +1,10 @@
 export * from "https://deno.land/x/willow_utils@0.2.1/mod.ts";
 
 export { FIFO } from "https://deno.land/x/fifo@v0.2.2/mod.ts";
-export { deferred } from "https://deno.land/std@0.202.0/async/deferred.ts";
+export {
+  type Deferred,
+  deferred,
+} from "https://deno.land/std@0.202.0/async/deferred.ts";
 export { concat } from "https://deno.land/std@0.202.0/bytes/concat.ts";
 export { equals as equalsBytes } from "https://deno.land/std@0.202.0/bytes/equals.ts";
 export { encode as encodeBase32 } from "https://deno.land/std@0.202.0/encoding/base32.ts";

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,6 +14,14 @@ export class ValidationError extends WillowError {
   }
 }
 
+/** Validation failed on an entry, keypair, etc. */
+export class WgpsMessageValidationError extends WillowError {
+  constructor(message?: string) {
+    super(message || "WGPS Message Validation error");
+    this.name = "WgpsMessageValidationError";
+  }
+}
+
 /** Check if any value is a subclass of WillowError (return true) or not (return false) */
 export function isErr<T>(x: T | Error): x is WillowError {
   return x instanceof WillowError;

--- a/src/wgps/decoding/decode_commitment_reveal.ts
+++ b/src/wgps/decoding/decode_commitment_reveal.ts
@@ -1,0 +1,16 @@
+import { MSG_COMMITMENT_REVEAL, MsgCommitmentReveal } from "../types.ts";
+import { GrowingBytes } from "./growing_bytes.ts";
+
+export async function decodeCommitmentReveal(
+  bytes: GrowingBytes,
+  challengeLength: number,
+): Promise<MsgCommitmentReveal> {
+  const commitmentBytes = await bytes.nextAbsolute(1 + challengeLength);
+
+  bytes.prune(1 + challengeLength);
+
+  return {
+    kind: MSG_COMMITMENT_REVEAL,
+    nonce: commitmentBytes.subarray(1, 1 + challengeLength),
+  };
+}

--- a/src/wgps/decoding/decode_messages.ts
+++ b/src/wgps/decoding/decode_messages.ts
@@ -1,0 +1,29 @@
+import { SyncMessage, Transport } from "../types.ts";
+import { decodeCommitmentReveal } from "./decode_commitment_reveal.ts";
+import { GrowingBytes } from "./growing_bytes.ts";
+
+export type DecodeMessagesOpts = {
+  transport: Transport;
+  challengeLength: number;
+};
+
+export async function* decodeMessages(
+  opts: DecodeMessagesOpts,
+): AsyncIterable<SyncMessage> {
+  const growingBytes = new GrowingBytes(opts.transport);
+
+  // TODO: Not while true, but while transport is open.
+  while (true) {
+    await growingBytes.nextAbsolute(1);
+
+    // Find out the type of decoder to use by bitmasking the first byte of the message.
+    const [firstByte] = growingBytes.array;
+
+    if (firstByte === 0) {
+      yield await decodeCommitmentReveal(
+        growingBytes,
+        opts.challengeLength,
+      );
+    }
+  }
+}

--- a/src/wgps/decoding/growing_bytes.test.ts
+++ b/src/wgps/decoding/growing_bytes.test.ts
@@ -1,0 +1,96 @@
+import { assertEquals } from "https://deno.land/std@0.202.0/assert/mod.ts";
+import { FIFO } from "../../../deps.ts";
+import { GrowingBytes } from "./growing_bytes.ts";
+import { delay } from "https://deno.land/std@0.202.0/async/delay.ts";
+
+Deno.test("GrowingBytes (relative)", async () => {
+  const fifo = new FIFO<Uint8Array>();
+
+  const bytes = new GrowingBytes(fifo);
+
+  assertEquals(bytes.array, new Uint8Array());
+
+  fifo.push(new Uint8Array([0]));
+
+  await delay(0);
+
+  assertEquals(bytes.array, new Uint8Array([0]));
+
+  fifo.push(new Uint8Array([1]));
+  fifo.push(new Uint8Array([2, 3]));
+
+  await delay(0);
+
+  assertEquals(bytes.array, new Uint8Array([0, 1, 2, 3]));
+
+  let received = new Uint8Array();
+
+  bytes.nextRelative(4).then((bytes) => {
+    received = bytes;
+  });
+
+  fifo.push(new Uint8Array([4]));
+  await delay(0);
+
+  assertEquals(received, new Uint8Array());
+
+  fifo.push(new Uint8Array([5, 6]));
+  await delay(0);
+
+  assertEquals(received, new Uint8Array());
+
+  fifo.push(new Uint8Array([7]));
+  await delay(0);
+
+  assertEquals(received, new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]));
+
+  bytes.prune(4);
+
+  assertEquals(bytes.array, new Uint8Array([4, 5, 6, 7]));
+});
+
+Deno.test("GrowingBytes (absolute)", async () => {
+  const fifo = new FIFO<Uint8Array>();
+
+  const bytes = new GrowingBytes(fifo);
+
+  assertEquals(bytes.array, new Uint8Array());
+
+  fifo.push(new Uint8Array([0]));
+
+  await delay(0);
+
+  assertEquals(bytes.array, new Uint8Array([0]));
+
+  fifo.push(new Uint8Array([1]));
+  fifo.push(new Uint8Array([2, 3]));
+
+  await delay(0);
+
+  assertEquals(bytes.array, new Uint8Array([0, 1, 2, 3]));
+
+  let received = new Uint8Array();
+
+  bytes.nextAbsolute(8).then((bytes) => {
+    received = bytes;
+  });
+
+  fifo.push(new Uint8Array([4]));
+  await delay(0);
+
+  assertEquals(received, new Uint8Array());
+
+  fifo.push(new Uint8Array([5, 6]));
+  await delay(0);
+
+  assertEquals(received, new Uint8Array());
+
+  fifo.push(new Uint8Array([7]));
+  await delay(0);
+
+  assertEquals(received, new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]));
+
+  bytes.prune(4);
+
+  assertEquals(bytes.array, new Uint8Array([4, 5, 6, 7]));
+});

--- a/src/wgps/decoding/growing_bytes.ts
+++ b/src/wgps/decoding/growing_bytes.ts
@@ -1,0 +1,63 @@
+import { concat, Deferred, deferred } from "../../../deps.ts";
+
+/** An array of growing bytes which can be awaited upon and pruned. */
+export class GrowingBytes {
+  array = new Uint8Array();
+
+  private deferredUntilLength: [number, Deferred<Uint8Array>] | null = null;
+
+  constructor(incoming: AsyncIterable<Uint8Array>) {
+    (async () => {
+      for await (const chunk of incoming) {
+        this.array = concat(this.array, chunk);
+
+        if (
+          this.deferredUntilLength &&
+          this.array.byteLength >= this.deferredUntilLength[0]
+        ) {
+          this.deferredUntilLength[1].resolve(this.array);
+          this.deferredUntilLength = null;
+        }
+      }
+    })();
+  }
+
+  /** Wait for the underyling Uint8Array to grow relative to the given length, regardless of the current length. */
+  nextRelative(length: number): Promise<Uint8Array> {
+    return this.next(length, true);
+  }
+
+  /** Wait for the underyling Uint8Array to grow to at least the absolute given length. */
+  nextAbsolute(length: number): Promise<Uint8Array> {
+    if (this.array.byteLength >= length) {
+      return Promise.resolve(this.array);
+    }
+
+    return this.next(length, false);
+  }
+
+  private next(ofLength: number, relative: boolean): Promise<Uint8Array> {
+    const target = relative ? this.array.byteLength + ofLength : ofLength;
+
+    if (
+      this.deferredUntilLength &&
+      this.deferredUntilLength[0] === target
+    ) {
+      return this.deferredUntilLength[1];
+    }
+
+    const deferredPromise = deferred<Uint8Array>();
+
+    this.deferredUntilLength = [
+      target,
+      deferredPromise,
+    ];
+
+    return deferredPromise;
+  }
+
+  /** Prunes the array by the given bytelength. */
+  prune(length: number) {
+    this.array = this.array.slice(length);
+  }
+}

--- a/src/wgps/encoding.test.ts
+++ b/src/wgps/encoding.test.ts
@@ -1,0 +1,39 @@
+import { delay } from "https://deno.land/std@0.202.0/async/delay.ts";
+import { decodeMessages } from "./decoding/decode_messages.ts";
+import { MessageEncoder } from "./encoding/message_encoder.ts";
+import { transportPairInMemory } from "./transports/in_memory.ts";
+import { MSG_COMMITMENT_REVEAL, SyncMessage } from "./types.ts";
+import { assertEquals } from "https://deno.land/std@0.202.0/assert/assert_equals.ts";
+
+Deno.test("Encoding roundtrip test", async () => {
+  const [alfie, betty] = transportPairInMemory();
+
+  const msgEncoder = new MessageEncoder(alfie);
+
+  const messages: SyncMessage[] = [];
+
+  (async () => {
+    for await (
+      const message of decodeMessages({
+        transport: betty,
+        challengeLength: 4,
+      })
+    ) {
+      messages.push(message);
+    }
+  })();
+
+  const nonce = crypto.getRandomValues(new Uint8Array(4));
+
+  msgEncoder.send({
+    kind: MSG_COMMITMENT_REVEAL,
+    nonce,
+  });
+
+  await delay(0);
+
+  assertEquals(messages, [{
+    kind: MSG_COMMITMENT_REVEAL,
+    nonce,
+  }]);
+});

--- a/src/wgps/encoding/encode_commitment_reveal.ts
+++ b/src/wgps/encoding/encode_commitment_reveal.ts
@@ -1,0 +1,9 @@
+import { concat } from "../../../deps.ts";
+import { MsgCommitmentReveal } from "../types.ts";
+
+export function encodeCommitmentReveal(msg: MsgCommitmentReveal): Uint8Array {
+  return concat(
+    new Uint8Array([0]),
+    msg.nonce,
+  );
+}

--- a/src/wgps/encoding/message_encoder.ts
+++ b/src/wgps/encoding/message_encoder.ts
@@ -1,0 +1,27 @@
+import { FIFO } from "../../../deps.ts";
+import { MSG_COMMITMENT_REVEAL, SyncMessage, Transport } from "../types.ts";
+import { encodeCommitmentReveal } from "./encode_commitment_reveal.ts";
+
+export class MessageEncoder {
+  private outgoing = new FIFO<Uint8Array>();
+
+  constructor(transport: Transport) {
+    (async () => {
+      for await (const bytes of this.outgoing) {
+        await transport.send(bytes);
+      }
+    })();
+  }
+
+  send(message: SyncMessage) {
+    let bytes: Uint8Array;
+
+    switch (message.kind) {
+      case MSG_COMMITMENT_REVEAL: {
+        bytes = encodeCommitmentReveal(message);
+      }
+    }
+
+    this.outgoing.push(bytes);
+  }
+}

--- a/src/wgps/ready_transport.test.ts
+++ b/src/wgps/ready_transport.test.ts
@@ -11,7 +11,7 @@ Deno.test("Ready transport receives max payload ", async () => {
 
     const readyTransport = new ReadyTransport({
       transport: alfie,
-      challengeLength: 4,
+      challengeHashLength: 4,
     });
 
     let received = new Uint8Array();
@@ -43,7 +43,7 @@ Deno.test("Ready transport receives max payload ", async () => {
 
     const readyTransport = new ReadyTransport({
       transport: alfie,
-      challengeLength: 4,
+      challengeHashLength: 4,
     });
 
     let received = new Uint8Array();
@@ -73,7 +73,7 @@ Deno.test("Ready transport receives max payload ", async () => {
 
     const readyTransport = new ReadyTransport({
       transport: alfie,
-      challengeLength: 4,
+      challengeHashLength: 4,
     });
 
     let received = new Uint8Array();
@@ -104,7 +104,7 @@ Deno.test("Ready transport receives max payload ", async () => {
 
     const readyTransport = new ReadyTransport({
       transport: alfie,
-      challengeLength: 4,
+      challengeHashLength: 4,
     });
 
     let received = new Uint8Array();

--- a/src/wgps/types.ts
+++ b/src/wgps/types.ts
@@ -15,3 +15,19 @@ export interface Transport {
   /** An async iterator of bytes received from the other peer via this transport. */
   [Symbol.asyncIterator](): AsyncIterator<Uint8Array>;
 }
+
+// Message types
+
+export const MSG_COMMITMENT_REVEAL = Symbol("msg_commitment_reveal");
+/** Complete the commitment scheme to determine the challenge for read authentication. */
+export type MsgCommitmentReveal = {
+  kind: typeof MSG_COMMITMENT_REVEAL;
+  /** The nonce of the sender, encoded as a big-endian unsigned integer. */
+  nonce: Uint8Array;
+};
+
+// Message groups
+
+export type ControlMessage = MsgCommitmentReveal;
+
+export type SyncMessage = ControlMessage;

--- a/src/wgps/wgps_messenger.test.ts
+++ b/src/wgps/wgps_messenger.test.ts
@@ -1,0 +1,40 @@
+import { assertEquals } from "https://deno.land/std@0.202.0/assert/mod.ts";
+import { transportPairInMemory } from "./transports/in_memory.ts";
+import { WgpsMessenger } from "./wgps_messenger.ts";
+
+Deno.test("WgpsMessenger establishes challenge", async () => {
+  const [alfie, betty] = transportPairInMemory();
+
+  const challengeHash = async (bytes: Uint8Array) => {
+    return new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+  };
+
+  const messengerAlfie = new WgpsMessenger({
+    challengeHash,
+    challengeLength: 128,
+    challengeHashLength: 32,
+    maxPayloadSizePower: 8,
+    transport: alfie,
+  });
+
+  const messengerBetty = new WgpsMessenger({
+    challengeHash,
+    challengeLength: 128,
+    challengeHashLength: 32,
+    maxPayloadSizePower: 8,
+    transport: betty,
+  });
+
+  // @ts-ignore looking at private values is fine
+  const alfieChallengeAlfie = await messengerAlfie.ourChallenge;
+  // @ts-ignore looking at private values is fine
+  const bettyChallengeAlfie = await messengerAlfie.theirChallenge;
+
+  // @ts-ignore looking at private values is fine
+  const alfieChallengeBetty = await messengerBetty.theirChallenge;
+  // @ts-ignore looking at private values is fine
+  const bettyChallengeBetty = await messengerBetty.ourChallenge;
+
+  assertEquals(alfieChallengeAlfie, alfieChallengeBetty);
+  assertEquals(bettyChallengeAlfie, bettyChallengeBetty);
+});

--- a/src/wgps/wgps_messenger.ts
+++ b/src/wgps/wgps_messenger.ts
@@ -1,0 +1,136 @@
+import { deferred, orderBytes } from "../../deps.ts";
+import { ValidationError, WgpsMessageValidationError } from "../errors.ts";
+import { decodeMessages } from "./decoding/decode_messages.ts";
+import { MessageEncoder } from "./encoding/message_encoder.ts";
+import { ReadyTransport } from "./ready_transport.ts";
+import {
+  IS_ALFIE,
+  MSG_COMMITMENT_REVEAL,
+  SyncMessage,
+  Transport,
+} from "./types.ts";
+
+export type WgpsMessengerOpts = {
+  transport: Transport;
+
+  /** Sets the maximum payload size for this peer, which is 2 to the power of the given number.
+   *
+   * The given power must be a natural number lesser than or equal to 64. */
+  maxPayloadSizePower: number;
+
+  challengeLength: number;
+  challengeHashLength: number;
+
+  challengeHash: (bytes: Uint8Array) => Promise<Uint8Array>;
+};
+
+/** Coordinates a complete WGPS synchronisation session. */
+export class WgpsMessenger {
+  private transport: ReadyTransport;
+  private encoder: MessageEncoder;
+
+  // Commitment scheme
+  private maxPayloadSizePower: number;
+
+  private challengeHash: (bytes: Uint8Array) => Promise<Uint8Array>;
+  private nonce: Uint8Array;
+  private ourChallenge = deferred<Uint8Array>();
+  private theirChallenge = deferred<Uint8Array>();
+
+  constructor(opts: WgpsMessengerOpts) {
+    if (opts.maxPayloadSizePower < 0 || opts.maxPayloadSizePower > 64) {
+      throw new ValidationError(
+        "maxPayloadSizePower must be a natural number less than or equal to 64",
+      );
+    }
+
+    this.nonce = crypto.getRandomValues(new Uint8Array(opts.challengeLength));
+
+    this.transport = new ReadyTransport({
+      transport: opts.transport,
+      challengeHashLength: opts.challengeHashLength,
+    });
+
+    // Plug our transport into a new encoder.
+    this.encoder = new MessageEncoder(this.transport);
+
+    // Start decoding incoming messages.
+    const decodedMessages = decodeMessages({
+      transport: this.transport,
+      challengeLength: opts.challengeLength,
+    });
+
+    // Begin handling decoded messages
+    (async () => {
+      for await (const message of decodedMessages) {
+        this.handleMessage(message);
+      }
+    })();
+
+    // Set private variables for commitment scheme
+    this.maxPayloadSizePower = opts.maxPayloadSizePower;
+    this.challengeHash = opts.challengeHash;
+
+    // Initiate commitment scheme.
+    this.initiate();
+  }
+
+  async initiate() {
+    // Send our max payload size.
+    await this.transport.send(new Uint8Array([this.maxPayloadSizePower]));
+
+    // Hash the nonce with the challenge-hashing function.
+    const commitment = await this.challengeHash(this.nonce);
+
+    // Send the digest of the nonce to the other peer.
+    await this.transport.send(commitment);
+
+    // Wait until we have the received commitment.
+    await this.transport.receivedCommitment;
+
+    // Now safe to send commitment reveal message.
+
+    this.encoder.send({
+      kind: MSG_COMMITMENT_REVEAL,
+      nonce: this.nonce,
+    });
+  }
+
+  async handleMessage(message: SyncMessage) {
+    switch (message.kind) {
+      case MSG_COMMITMENT_REVEAL: {
+        // Determine challenges.
+        const receivedCommitment = await this.transport.receivedCommitment;
+        const digest = await this.challengeHash(message.nonce);
+
+        if (orderBytes(receivedCommitment, digest) !== 0) {
+          throw new WgpsMessageValidationError(
+            "Digest of revealed commitment did not match other side's received commitment.",
+          );
+        }
+
+        const xor = (a: Uint8Array, b: Uint8Array, complementary = false) => {
+          const xored = new Uint8Array(a.byteLength);
+
+          for (let i = 0; i < a.byteLength; i++) {
+            xored.set([
+              complementary ? ~(a[i] ^ b[i]) : (a[i] ^ b[i]),
+            ], i);
+          }
+
+          return xored;
+        };
+
+        // If alfie, bitwise XOR of our nonce and received nonce.
+        if (this.transport.role === IS_ALFIE) {
+          this.ourChallenge.resolve(xor(this.nonce, message.nonce));
+          this.theirChallenge.resolve(xor(this.nonce, message.nonce, true));
+        } else {
+          // If betty, bitwise complement of XOR of our nonce and received nonce.
+          this.ourChallenge.resolve(xor(this.nonce, message.nonce, true));
+          this.theirChallenge.resolve(xor(this.nonce, message.nonce));
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added a `WgpsMessenger` which will eventually be able to carry out a WGPS synchronisation session. Currently it is able to interactively establish the challenges used to sign when proving ownership of a secret key.

Added a `SyncMessage` type.
Added a `ControlMessage` type.
Added a `MsgCommitmentReveal` type.

Added `MessageEncoder`, which picks the right encoder for a given message, encodes it, and queues them for sending via transport.

Added `GrowingBytes`, a wrapper for a Uint8Array which is provides methods for awaiting until the underlying bytes have grown to an absolute size or a size relative to the current size. This is for the decoders which need to handle messages as they stream in.

Added `decodeMessages` generator function which detects which decoder should be used.

Added `decodeCommitmentReveal` (streaming)
Added `encodeCommitmentReveal` (non-streaming)

Add `WgpsMessageValidationError` for throwing when we get an invalid message from another peer.

Updated `ReadyTransport` to take a challenge _hash_ length instead of a challenge length as one of its params. The passed value can be any number.