### PR TITLE
WGPS: Setup phase

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,4 @@
-//export * from "https://deno.land/x/willow_utils@0.3.0/mod.ts";
-export * from "../willow_utils/mod.ts";
+export * from "https://deno.land/x/willow_utils@0.4.0/mod.ts";
 export { FIFO } from "https://deno.land/x/fifo@v0.2.2/mod.ts";
 export {
   type Deferred,

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,5 @@
-export * from "https://deno.land/x/willow_utils@0.3.0/mod.ts";
+//export * from "https://deno.land/x/willow_utils@0.3.0/mod.ts";
+export * from "../willow_utils/mod.ts";
 export { FIFO } from "https://deno.land/x/fifo@v0.2.2/mod.ts";
 export {
   type Deferred,

--- a/src/wgps/decoding/control.ts
+++ b/src/wgps/decoding/control.ts
@@ -1,4 +1,5 @@
 import { decodeCompactWidth, GrowingBytes } from "../../../deps.ts";
+import { WillowError } from "../../errors.ts";
 import {
   HandleType,
   LogicalChannel,
@@ -18,30 +19,33 @@ import {
 import { compactWidthFromEndOfByte } from "./util.ts";
 
 export function decodeChannelFromBeginningOfByte(byte: number): LogicalChannel {
-  if ((byte & 0x28) === 0x28) {
+  if ((byte & 0x60) === 0x60) {
+    return LogicalChannel.CapabilityChannel;
+  } else if ((byte & 0x40) === 0x40) {
     return LogicalChannel.IntersectionChannel;
   }
 
-  // TODO: Remove this when we have more logical channels worked in.
-  return LogicalChannel.IntersectionChannel;
+  throw new WillowError("Couldn't decode logical channel");
 }
 
 export function decodeChannelFromEndOfByte(byte: number): LogicalChannel {
-  if ((byte & 0x2) === 0x2) {
+  if ((byte & 0x3) === 0x3) {
+    return LogicalChannel.CapabilityChannel;
+  } else if ((byte & 0x2) === 0x2) {
     return LogicalChannel.IntersectionChannel;
   }
 
-  // TODO: Remove this when we have more logical channels worked in.
-  return LogicalChannel.IntersectionChannel;
+  throw new WillowError("Couldn't decode logical channel");
 }
 
 export function decodeHandleTypeFromBeginningOfByte(byte: number): HandleType {
-  if ((byte & 0x0) === 0x0) {
+  if ((byte & 0x20) === 0x20) {
+    return HandleType.CapabilityHandle;
+  } else if ((byte & 0x0) === 0x0) {
     return HandleType.IntersectionHandle;
   }
 
-  // TODO: Remove this when we have more handle types worked in.
-  return HandleType.IntersectionHandle;
+  throw new WillowError("Couldn't decode handle type");
 }
 
 export async function decodeControlIssueGuarantee(

--- a/src/wgps/decoding/decode_messages.ts
+++ b/src/wgps/decoding/decode_messages.ts
@@ -24,6 +24,7 @@ import {
 import {
   decodeSetupBindAreaOfInterest,
   decodeSetupBindReadCapability,
+  decodeSetupBindStaticToken,
 } from "./setup.ts";
 
 export type DecodeMessagesOpts<
@@ -37,6 +38,7 @@ export type DecodeMessagesOpts<
   SubspaceReceiver,
   SyncSubspaceSignature,
   SubspaceSecretKey,
+  StaticToken,
   NamespaceId,
   SubspaceId,
 > = {
@@ -51,6 +53,7 @@ export type DecodeMessagesOpts<
     SubspaceReceiver,
     SyncSubspaceSignature,
     SubspaceSecretKey,
+    StaticToken,
     NamespaceId,
     SubspaceId
   >;
@@ -62,6 +65,7 @@ export type DecodeMessagesOpts<
     PsiGroup,
     SubspaceCapability,
     SyncSubspaceSignature,
+    StaticToken,
     NamespaceId,
     SubspaceId
   >;
@@ -82,6 +86,7 @@ export async function* decodeMessages<
   SubspaceReceiver,
   SyncSubspaceSignature,
   SubspaceSecretKey,
+  StaticToken,
   NamespaceId,
   SubspaceId,
 >(
@@ -96,6 +101,7 @@ export async function* decodeMessages<
     SubspaceReceiver,
     SyncSubspaceSignature,
     SubspaceSecretKey,
+    StaticToken,
     NamespaceId,
     SubspaceId
   >,
@@ -106,6 +112,7 @@ export async function* decodeMessages<
     PsiGroup,
     SubspaceCapability,
     SyncSubspaceSignature,
+    StaticToken,
     SubspaceId
   >
 > {
@@ -141,6 +148,12 @@ export async function* decodeMessages<
     } else if ((firstByte & 0x80) === 0x80) {
       // Control Issue Guarantee.
       yield await decodeControlIssueGuarantee(bytes);
+    } else if ((firstByte & 0x30) === 0x30) {
+      // Setup Bind Static Token
+      yield await decodeSetupBindStaticToken(
+        bytes,
+        opts.encodings.staticToken.decodeStream,
+      );
     } else if ((firstByte & 0x28) === 0x28) {
       // Setup Bind Area of Interest
       yield await decodeSetupBindAreaOfInterest(

--- a/src/wgps/decoding/setup.ts
+++ b/src/wgps/decoding/setup.ts
@@ -9,8 +9,10 @@ import {
 import {
   MSG_SETUP_BIND_AREA_OF_INTEREST,
   MSG_SETUP_BIND_READ_CAPABILITY,
+  MSG_SETUP_BIND_STATIC_TOKEN,
   MsgSetupBindAreaOfInterest,
   MsgSetupBindReadCapability,
+  MsgSetupBindStaticToken,
   ReadCapEncodingScheme,
   ReadCapPrivy,
 } from "../types.ts";
@@ -127,5 +129,21 @@ export async function decodeSetupBindAreaOfInterest<SubspaceId>(
       maxSize: BigInt(maxSize),
     },
     authorisation: BigInt(authHandle),
+  };
+}
+
+export async function decodeSetupBindStaticToken<StaticToken>(
+  bytes: GrowingBytes,
+  decodeStaticToken: (bytes: GrowingBytes) => Promise<StaticToken>,
+): Promise<MsgSetupBindStaticToken<StaticToken>> {
+  await bytes.nextAbsolute(1);
+
+  bytes.prune(1);
+
+  const staticToken = await decodeStaticToken(bytes);
+
+  return {
+    kind: MSG_SETUP_BIND_STATIC_TOKEN,
+    staticToken,
   };
 }

--- a/src/wgps/decoding/setup.ts
+++ b/src/wgps/decoding/setup.ts
@@ -1,0 +1,33 @@
+import { decodeCompactWidth, GrowingBytes } from "../../../deps.ts";
+import {
+  MSG_SETUP_BIND_READ_CAPABILITY,
+  MsgSetupBindReadCapability,
+} from "../types.ts";
+import { compactWidthFromEndOfByte } from "./util.ts";
+
+export async function decodeSetupBindReadCapability<
+  ReadCapabilityPartial,
+  SyncSignature,
+>(
+  bytes: GrowingBytes,
+  decodeReadCapPartial: (bytes: GrowingBytes) => Promise<ReadCapabilityPartial>,
+  decodeSignature: (bytes: GrowingBytes) => Promise<SyncSignature>,
+): Promise<MsgSetupBindReadCapability<ReadCapabilityPartial, SyncSignature>> {
+  await bytes.nextAbsolute(1);
+
+  const compactWidth = compactWidthFromEndOfByte(bytes.array[0]);
+
+  const handle = decodeCompactWidth(bytes.array.subarray(1, 1 + compactWidth));
+
+  bytes.prune(1 + compactWidth);
+
+  const capability = await decodeReadCapPartial(bytes);
+  const signature = await decodeSignature(bytes);
+
+  return {
+    kind: MSG_SETUP_BIND_READ_CAPABILITY,
+    handle: BigInt(handle),
+    capability,
+    signature,
+  };
+}

--- a/src/wgps/decoding/setup.ts
+++ b/src/wgps/decoding/setup.ts
@@ -1,27 +1,49 @@
-import { decodeCompactWidth, GrowingBytes } from "../../../deps.ts";
 import {
+  Area,
+  decodeCompactWidth,
+  decodeStreamAreaInArea,
+  EncodingScheme,
+  GrowingBytes,
+  PathScheme,
+} from "../../../deps.ts";
+import {
+  MSG_SETUP_BIND_AREA_OF_INTEREST,
   MSG_SETUP_BIND_READ_CAPABILITY,
+  MsgSetupBindAreaOfInterest,
   MsgSetupBindReadCapability,
+  ReadCapEncodingScheme,
+  ReadCapPrivy,
 } from "../types.ts";
 import { compactWidthFromEndOfByte } from "./util.ts";
 
 export async function decodeSetupBindReadCapability<
-  ReadCapabilityPartial,
+  ReadCapability,
   SyncSignature,
+  NamespaceId,
+  SubspaceId,
 >(
   bytes: GrowingBytes,
-  decodeReadCapPartial: (bytes: GrowingBytes) => Promise<ReadCapabilityPartial>,
+  readCapScheme: ReadCapEncodingScheme<
+    ReadCapability,
+    NamespaceId,
+    SubspaceId
+  >,
+  getPrivy: (handle: bigint) => ReadCapPrivy<NamespaceId, SubspaceId>,
   decodeSignature: (bytes: GrowingBytes) => Promise<SyncSignature>,
-): Promise<MsgSetupBindReadCapability<ReadCapabilityPartial, SyncSignature>> {
+): Promise<MsgSetupBindReadCapability<ReadCapability, SyncSignature>> {
   await bytes.nextAbsolute(1);
 
   const compactWidth = compactWidthFromEndOfByte(bytes.array[0]);
+
+  await bytes.nextAbsolute(1 + compactWidth);
 
   const handle = decodeCompactWidth(bytes.array.subarray(1, 1 + compactWidth));
 
   bytes.prune(1 + compactWidth);
 
-  const capability = await decodeReadCapPartial(bytes);
+  const privy = getPrivy(BigInt(handle));
+
+  const capability = await readCapScheme.decodeStream(bytes, privy);
   const signature = await decodeSignature(bytes);
 
   return {
@@ -29,5 +51,81 @@ export async function decodeSetupBindReadCapability<
     handle: BigInt(handle),
     capability,
     signature,
+  };
+}
+
+export async function decodeSetupBindAreaOfInterest<SubspaceId>(
+  bytes: GrowingBytes,
+  getPrivy: (handle: bigint) => Promise<Area<SubspaceId>>,
+  decodeStreamSubspace: EncodingScheme<SubspaceId>["decodeStream"],
+  pathScheme: PathScheme,
+): Promise<MsgSetupBindAreaOfInterest<SubspaceId>> {
+  await bytes.nextAbsolute(1);
+
+  const hasALimit = (0x4 & bytes.array[0]) == 0x4;
+
+  const compactWidth = compactWidthFromEndOfByte(bytes.array[0]);
+
+  await bytes.nextAbsolute(1 + compactWidth);
+
+  const authHandle = decodeCompactWidth(
+    bytes.array.subarray(1, 1 + compactWidth),
+  );
+
+  bytes.prune(1 + compactWidth);
+
+  const outer = await getPrivy(BigInt(authHandle));
+
+  const area = await decodeStreamAreaInArea(
+    {
+      decodeStreamSubspace,
+      pathScheme,
+    },
+    bytes,
+    outer,
+  );
+
+  if (!hasALimit) {
+    return {
+      kind: MSG_SETUP_BIND_AREA_OF_INTEREST,
+      areaOfInterest: {
+        area: area,
+        maxCount: 0,
+        maxSize: BigInt(0),
+      },
+      authorisation: BigInt(authHandle),
+    };
+  }
+
+  await bytes.nextAbsolute(1);
+
+  const maxes = bytes.array[0];
+
+  const compactWidthCount = compactWidthFromEndOfByte(maxes >> 6);
+  const compactWidthSize = compactWidthFromEndOfByte(maxes >> 4);
+
+  await bytes.nextAbsolute(1 + compactWidthCount + compactWidthSize);
+
+  const maxCount = decodeCompactWidth(
+    bytes.array.subarray(1, 1 + compactWidthCount),
+  );
+
+  const maxSize = decodeCompactWidth(
+    bytes.array.subarray(
+      1 + compactWidthCount,
+      1 + compactWidthCount + compactWidthSize,
+    ),
+  );
+
+  bytes.prune(1 + compactWidthCount + compactWidthSize);
+
+  return {
+    kind: MSG_SETUP_BIND_AREA_OF_INTEREST,
+    areaOfInterest: {
+      area: area,
+      maxCount: Number(maxCount),
+      maxSize: BigInt(maxSize),
+    },
+    authorisation: BigInt(authHandle),
   };
 }

--- a/src/wgps/encoding.test.ts
+++ b/src/wgps/encoding.test.ts
@@ -18,6 +18,7 @@ import {
   MSG_PAI_REQUEST_SUBSPACE_CAPABILITY,
   MSG_SETUP_BIND_AREA_OF_INTEREST,
   MSG_SETUP_BIND_READ_CAPABILITY,
+  MSG_SETUP_BIND_STATIC_TOKEN,
   SyncEncodings,
   SyncMessage,
   SyncSchemes,
@@ -28,6 +29,7 @@ import {
   TestNamespace,
   TestReadCap,
   testSchemeAccessControl,
+  testSchemeAuthorisationToken,
   testSchemeNamespace,
   testSchemePai,
   testSchemePath,
@@ -46,6 +48,7 @@ const vectors: SyncMessage<
   Uint8Array,
   TestSubspaceReadCap,
   Uint8Array,
+  TestSubspace,
   TestSubspace
 >[] = [
   {
@@ -322,6 +325,11 @@ const vectors: SyncMessage<
       maxSize: BigInt(3400),
     },
   },
+
+  {
+    kind: MSG_SETUP_BIND_STATIC_TOKEN,
+    staticToken: TestSubspace.Epson,
+  },
 ];
 
 Deno.test("Encoding roundtrip test", async () => {
@@ -333,6 +341,7 @@ Deno.test("Encoding roundtrip test", async () => {
     Uint8Array,
     TestSubspaceReadCap,
     Uint8Array,
+    TestSubspace,
     TestNamespace,
     TestSubspace
   > = {
@@ -343,6 +352,7 @@ Deno.test("Encoding roundtrip test", async () => {
     readCapability: testSchemeAccessControl.encodings.readCapability,
     subspace: testSchemeSubspace,
     syncSignature: testSchemeAccessControl.encodings.syncSignature,
+    staticToken: testSchemeAuthorisationToken.encodings.staticToken,
   };
 
   const schemes: SyncSchemes<
@@ -356,6 +366,7 @@ Deno.test("Encoding roundtrip test", async () => {
     TestSubspace,
     Uint8Array,
     TestSubspace,
+    TestSubspace,
     TestNamespace,
     TestSubspace
   > = {
@@ -365,6 +376,7 @@ Deno.test("Encoding roundtrip test", async () => {
     path: testSchemePath,
     subspace: testSchemeSubspace,
     subspaceCap: testSchemeSubspaceCap,
+    authorisationToken: testSchemeAuthorisationToken,
   };
 
   const msgEncoder = new MessageEncoder(encodings, schemes, {
@@ -428,6 +440,7 @@ Deno.test("Encoding roundtrip test", async () => {
     Uint8Array,
     TestSubspaceReadCap,
     Uint8Array,
+    TestSubspace,
     TestSubspace
   >[] = [];
 

--- a/src/wgps/encoding/control.ts
+++ b/src/wgps/encoding/control.ts
@@ -21,6 +21,8 @@ export function channelMaskStart(
       return mask | 0x60;
     case LogicalChannel.AreaOfInterestChannel:
       return mask | 0x80;
+    case LogicalChannel.StaticTokenChannel:
+      return mask | 0xc0;
   }
 }
 
@@ -32,6 +34,8 @@ export function channelMaskEnd(mask: number, channel: LogicalChannel): number {
       return mask | 0x3;
     case LogicalChannel.AreaOfInterestChannel:
       return mask | 0x4;
+    case LogicalChannel.StaticTokenChannel:
+      return mask | 0x6;
   }
 }
 
@@ -43,6 +47,8 @@ export function handleMask(mask: number, handleType: HandleType): number {
       return mask | 0x20;
     case HandleType.AreaOfInterestHandle:
       return mask | 0x40;
+    case HandleType.StaticTokenHandle:
+      return mask | 0x80;
   }
 }
 

--- a/src/wgps/encoding/control.ts
+++ b/src/wgps/encoding/control.ts
@@ -19,6 +19,8 @@ export function channelMaskStart(
       return mask | 0x40;
     case LogicalChannel.CapabilityChannel:
       return mask | 0x60;
+    case LogicalChannel.AreaOfInterestChannel:
+      return mask | 0x80;
   }
 }
 
@@ -28,6 +30,8 @@ export function channelMaskEnd(mask: number, channel: LogicalChannel): number {
       return mask | 0x2;
     case LogicalChannel.CapabilityChannel:
       return mask | 0x3;
+    case LogicalChannel.AreaOfInterestChannel:
+      return mask | 0x4;
   }
 }
 
@@ -37,6 +41,8 @@ export function handleMask(mask: number, handleType: HandleType): number {
       return mask;
     case HandleType.CapabilityHandle:
       return mask | 0x20;
+    case HandleType.AreaOfInterestHandle:
+      return mask | 0x40;
   }
 }
 

--- a/src/wgps/encoding/control.ts
+++ b/src/wgps/encoding/control.ts
@@ -10,24 +10,33 @@ import {
   MsgControlPlead,
 } from "../types.ts";
 
-export function channelMaskStart(mask: number, channel: LogicalChannel) {
+export function channelMaskStart(
+  mask: number,
+  channel: LogicalChannel,
+): number {
   switch (channel) {
     case LogicalChannel.IntersectionChannel:
-      return mask | 0x64;
+      return mask | 0x40;
+    case LogicalChannel.CapabilityChannel:
+      return mask | 0x60;
   }
 }
 
-export function channelMaskEnd(mask: number, channel: LogicalChannel) {
+export function channelMaskEnd(mask: number, channel: LogicalChannel): number {
   switch (channel) {
     case LogicalChannel.IntersectionChannel:
       return mask | 0x2;
+    case LogicalChannel.CapabilityChannel:
+      return mask | 0x3;
   }
 }
 
-export function handleMask(mask: number, handleType: HandleType) {
+export function handleMask(mask: number, handleType: HandleType): number {
   switch (handleType) {
     case HandleType.IntersectionHandle:
       return mask;
+    case HandleType.CapabilityHandle:
+      return mask | 0x20;
   }
 }
 

--- a/src/wgps/encoding/message_encoder.ts
+++ b/src/wgps/encoding/message_encoder.ts
@@ -15,6 +15,7 @@ import {
   MSG_PAI_REQUEST_SUBSPACE_CAPABILITY,
   MSG_SETUP_BIND_AREA_OF_INTEREST,
   MSG_SETUP_BIND_READ_CAPABILITY,
+  MSG_SETUP_BIND_STATIC_TOKEN,
   ReadCapPrivy,
   SyncEncodings,
   SyncMessage,
@@ -38,6 +39,7 @@ import {
 import {
   encodeSetupBindAreaOfInterest,
   encodeSetupBindReadCapability,
+  encodeSetupBindStaticToken,
 } from "./setup.ts";
 
 export type EncodedSyncMessage = {
@@ -56,6 +58,7 @@ export class MessageEncoder<
   SubspaceReceiver,
   SyncSubspaceSignature,
   SubspaceSecretKey,
+  StaticToken,
   NamespaceId,
   SubspaceId,
 > {
@@ -68,6 +71,7 @@ export class MessageEncoder<
       PsiGroup,
       SubspaceCapability,
       SyncSubspaceSignature,
+      StaticToken,
       NamespaceId,
       SubspaceId
     >,
@@ -82,6 +86,7 @@ export class MessageEncoder<
       SubspaceReceiver,
       SyncSubspaceSignature,
       SubspaceSecretKey,
+      StaticToken,
       NamespaceId,
       SubspaceId
     >,
@@ -107,6 +112,7 @@ export class MessageEncoder<
       PsiGroup,
       SubspaceCapability,
       SyncSubspaceSignature,
+      StaticToken,
       SubspaceId
     >,
   ) {
@@ -218,6 +224,16 @@ export class MessageEncoder<
         );
 
         push(LogicalChannel.AreaOfInterestChannel, bytes);
+        break;
+      }
+
+      case MSG_SETUP_BIND_STATIC_TOKEN: {
+        const bytes = encodeSetupBindStaticToken(
+          message,
+          this.encodings.staticToken.encode,
+        );
+
+        push(LogicalChannel.StaticTokenChannel, bytes);
         break;
       }
 

--- a/src/wgps/encoding/setup.ts
+++ b/src/wgps/encoding/setup.ts
@@ -1,0 +1,23 @@
+import { compactWidth, concat, encodeCompactWidth } from "../../../deps.ts";
+import { MsgSetupBindReadCapability } from "../types.ts";
+import { compactWidthOr } from "./util.ts";
+
+export function encodeSetupBindReadCapability<
+  ReadCapabilityPartial,
+  SyncSignature,
+>(
+  msg: MsgSetupBindReadCapability<ReadCapabilityPartial, SyncSignature>,
+  encodeReadCapability: (cap: ReadCapabilityPartial) => Uint8Array,
+  encodeSignature: (sig: SyncSignature) => Uint8Array,
+) {
+  const handleWidth = compactWidth(msg.handle);
+
+  const header = compactWidthOr(0x20, handleWidth);
+
+  return concat(
+    new Uint8Array([header]),
+    encodeCompactWidth(msg.handle),
+    encodeReadCapability(msg.capability),
+    encodeSignature(msg.signature),
+  );
+}

--- a/src/wgps/encoding/setup.ts
+++ b/src/wgps/encoding/setup.ts
@@ -10,6 +10,7 @@ import {
 import {
   MsgSetupBindAreaOfInterest,
   MsgSetupBindReadCapability,
+  MsgSetupBindStaticToken,
   ReadCapEncodingScheme,
   ReadCapPrivy,
 } from "../types.ts";
@@ -100,5 +101,15 @@ export function encodeSetupBindAreaOfInterest<SubspaceId>(
     new Uint8Array([lengthBytes]),
     encodeCompactWidth(msg.areaOfInterest.maxCount),
     encodeCompactWidth(msg.areaOfInterest.maxSize),
+  );
+}
+
+export function encodeSetupBindStaticToken<StaticToken>(
+  msg: MsgSetupBindStaticToken<StaticToken>,
+  encodeStaticToken: (token: StaticToken) => Uint8Array,
+) {
+  return concat(
+    new Uint8Array([0x30]),
+    encodeStaticToken(msg.staticToken),
   );
 }

--- a/src/wgps/encoding/setup.ts
+++ b/src/wgps/encoding/setup.ts
@@ -1,15 +1,35 @@
-import { compactWidth, concat, encodeCompactWidth } from "../../../deps.ts";
-import { MsgSetupBindReadCapability } from "../types.ts";
+import {
+  Area,
+  compactWidth,
+  concat,
+  encodeAreaInArea,
+  encodeCompactWidth,
+  PathScheme,
+  TotalOrder,
+} from "../../../deps.ts";
+import {
+  MsgSetupBindAreaOfInterest,
+  MsgSetupBindReadCapability,
+  ReadCapEncodingScheme,
+  ReadCapPrivy,
+} from "../types.ts";
 import { compactWidthOr } from "./util.ts";
 
 export function encodeSetupBindReadCapability<
-  ReadCapabilityPartial,
+  ReadCapability,
   SyncSignature,
+  NamespaceId,
+  SubspaceId,
 >(
-  msg: MsgSetupBindReadCapability<ReadCapabilityPartial, SyncSignature>,
-  encodeReadCapability: (cap: ReadCapabilityPartial) => Uint8Array,
+  msg: MsgSetupBindReadCapability<ReadCapability, SyncSignature>,
+  encodeReadCapability: ReadCapEncodingScheme<
+    ReadCapability,
+    NamespaceId,
+    SubspaceId
+  >["encode"],
   encodeSignature: (sig: SyncSignature) => Uint8Array,
-) {
+  privy: ReadCapPrivy<NamespaceId, SubspaceId>,
+): Uint8Array {
   const handleWidth = compactWidth(msg.handle);
 
   const header = compactWidthOr(0x20, handleWidth);
@@ -17,7 +37,68 @@ export function encodeSetupBindReadCapability<
   return concat(
     new Uint8Array([header]),
     encodeCompactWidth(msg.handle),
-    encodeReadCapability(msg.capability),
+    encodeReadCapability(msg.capability, privy),
     encodeSignature(msg.signature),
+  );
+}
+
+export function encodeSetupBindAreaOfInterest<SubspaceId>(
+  msg: MsgSetupBindAreaOfInterest<SubspaceId>,
+  opts: {
+    outer: Area<SubspaceId>;
+    pathScheme: PathScheme;
+    encodeSubspace: (subspace: SubspaceId) => Uint8Array;
+    orderSubspace: TotalOrder<SubspaceId>;
+  },
+): Uint8Array {
+  // 0x28 masked with compact width of authorisation handle
+  // AND masked with 1 at 5th bit if either max count or max size is
+
+  const header = compactWidthOr(0x28, compactWidth(msg.authorisation)) |
+    ((msg.areaOfInterest.maxCount !== 0 ||
+        msg.areaOfInterest.maxSize !== BigInt(0))
+      ? 0x4
+      : 0x0);
+
+  const authHandle = encodeCompactWidth(msg.authorisation);
+
+  const areaInArea = encodeAreaInArea(
+    {
+      pathScheme: opts.pathScheme,
+      encodeSubspace: opts.encodeSubspace,
+      orderSubspace: opts.orderSubspace,
+    },
+    msg.areaOfInterest.area,
+    opts.outer,
+  );
+
+  if (
+    msg.areaOfInterest.maxCount === 0 &&
+    msg.areaOfInterest.maxSize === BigInt(0)
+  ) {
+    return concat(new Uint8Array([header]), authHandle, areaInArea);
+  }
+
+  const maxCountMask = compactWidthOr(
+    0,
+    compactWidth(msg.areaOfInterest.maxCount),
+  );
+
+  const shifted = maxCountMask << 2;
+
+  const maxSizeMask = compactWidthOr(
+    shifted,
+    compactWidth(msg.areaOfInterest.maxSize),
+  );
+
+  const lengthBytes = maxSizeMask << 4;
+
+  return concat(
+    new Uint8Array([header]),
+    authHandle,
+    areaInArea,
+    new Uint8Array([lengthBytes]),
+    encodeCompactWidth(msg.areaOfInterest.maxCount),
+    encodeCompactWidth(msg.areaOfInterest.maxSize),
   );
 }

--- a/src/wgps/encoding/util.ts
+++ b/src/wgps/encoding/util.ts
@@ -1,0 +1,13 @@
+const compactWidthMasks: Record<1 | 2 | 4 | 8, number> = {
+  1: 0x0,
+  2: 0x1,
+  4: 0x2,
+  8: 0x3,
+};
+
+export function compactWidthOr(
+  byte: number,
+  compactWidth: 1 | 2 | 4 | 8,
+): number {
+  return byte | compactWidthMasks[compactWidth];
+}

--- a/src/wgps/encoding/util.ts
+++ b/src/wgps/encoding/util.ts
@@ -1,4 +1,4 @@
-const compactWidthMasks: Record<1 | 2 | 4 | 8, number> = {
+const compactWidthEndMasks: Record<1 | 2 | 4 | 8, number> = {
   1: 0x0,
   2: 0x1,
   4: 0x2,
@@ -9,5 +9,5 @@ export function compactWidthOr(
   byte: number,
   compactWidth: 1 | 2 | 4 | 8,
 ): number {
-  return byte | compactWidthMasks[compactWidth];
+  return byte | compactWidthEndMasks[compactWidth];
 }

--- a/src/wgps/pai/types.ts
+++ b/src/wgps/pai/types.ts
@@ -40,17 +40,17 @@ export type FragmentKit<NamespaceId, SubspaceId> =
   | FragmentKitSelective<NamespaceId, SubspaceId>;
 
 export type PaiScheme<
+  ReadCapability,
+  PsiGroup,
+  PsiScalar,
   NamespaceId,
   SubspaceId,
-  PsiGroup,
-  Scalar,
-  ReadCapability,
 > = {
   fragmentToGroup: (
     fragment: Fragment<NamespaceId, SubspaceId>,
   ) => Promise<PsiGroup>;
-  getScalar: () => Scalar;
-  scalarMult: (group: PsiGroup, scalar: Scalar) => PsiGroup;
+  getScalar: () => PsiScalar;
+  scalarMult: (group: PsiGroup, scalar: PsiScalar) => PsiGroup;
   isGroupEqual: (a: PsiGroup, b: PsiGroup) => boolean;
   getFragmentKit: (cap: ReadCapability) => FragmentKit<NamespaceId, SubspaceId>;
   groupMemberEncoding: EncodingScheme<PsiGroup>;

--- a/src/wgps/util.ts
+++ b/src/wgps/util.ts
@@ -3,20 +3,14 @@ import { ReadAuthorisation } from "./types.ts";
 export function isSubspaceReadAuthorisation<
   ReadCapability,
   SubspaceReadCapability,
-  SyncSignature,
-  SyncSubspaceSignature,
 >(
   authorisation: ReadAuthorisation<
     ReadCapability,
-    SubspaceReadCapability,
-    SyncSignature,
-    SyncSubspaceSignature
+    SubspaceReadCapability
   >,
 ): authorisation is {
   capability: ReadCapability;
   subspaceCapability: SubspaceReadCapability;
-  signature: SyncSignature;
-  subspaceSignature: SyncSubspaceSignature;
 } {
   if ("subspaceCapability" in authorisation) {
     return true;

--- a/src/wgps/wgps_messenger.test.ts
+++ b/src/wgps/wgps_messenger.test.ts
@@ -5,6 +5,7 @@ import {
   TestNamespace,
   TestReadCap,
   testSchemeAccessControl,
+  testSchemeAuthorisationToken,
   testSchemeNamespace,
   testSchemePai,
   testSchemePath,
@@ -35,6 +36,7 @@ Deno.test("WgpsMessenger establishes challenge", async () => {
       pai: testSchemePai,
       path: testSchemePath,
       subspace: testSchemeSubspace,
+      authorisationToken: testSchemeAuthorisationToken,
     },
     interests: new Map([[
       {
@@ -77,6 +79,7 @@ Deno.test("WgpsMessenger establishes challenge", async () => {
       pai: testSchemePai,
       path: testSchemePath,
       subspace: testSchemeSubspace,
+      authorisationToken: testSchemeAuthorisationToken,
     },
     interests: new Map([[
       {
@@ -120,4 +123,35 @@ Deno.test("WgpsMessenger establishes challenge", async () => {
   assertEquals(bettyChallengeAlfie, bettyChallengeBetty);
 
   await delay(10);
+
+  // @ts-ignore looking at private values is fine
+  const receivedCapsAlfie = Array.from(messengerAlfie.handlesCapsTheirs).map((
+    [, cap],
+  ) => cap);
+  // @ts-ignore looking at private values is fine
+  const receivedCapsBetty = Array.from(messengerBetty.handlesCapsTheirs).map((
+    [, cap],
+  ) => cap);
+
+  assertEquals(receivedCapsAlfie, [{
+    namespace: TestNamespace.Family,
+    subspace: TestSubspace.Gemma,
+    path: [new Uint8Array([1])],
+    receiver: TestSubspace.Betty,
+    time: {
+      start: BigInt(0),
+      end: OPEN_END,
+    },
+  }]);
+
+  assertEquals(receivedCapsBetty, [{
+    namespace: TestNamespace.Family,
+    subspace: TestSubspace.Gemma,
+    path: [new Uint8Array([1])],
+    receiver: TestSubspace.Alfie,
+    time: {
+      start: BigInt(0),
+      end: OPEN_END,
+    },
+  }]);
 });

--- a/src/wgps/wgps_messenger.test.ts
+++ b/src/wgps/wgps_messenger.test.ts
@@ -3,9 +3,12 @@ import { transportPairInMemory } from "./transports/in_memory.ts";
 import { WgpsMessenger } from "./wgps_messenger.ts";
 import {
   TestNamespace,
+  TestReadCap,
   testSchemeAccessControl,
   testSchemeNamespace,
   testSchemePai,
+  testSchemePath,
+  testSchemeSubspace,
   testSchemeSubspaceCap,
   TestSubspace,
 } from "../test/test_schemes.ts";
@@ -30,8 +33,10 @@ Deno.test("WgpsMessenger establishes challenge", async () => {
       namespace: testSchemeNamespace,
       accessControl: testSchemeAccessControl,
       pai: testSchemePai,
+      path: testSchemePath,
+      subspace: testSchemeSubspace,
     },
-    readAuthorisations: [
+    interests: new Map([[
       {
         capability: {
           namespace: TestNamespace.Family,
@@ -42,10 +47,21 @@ Deno.test("WgpsMessenger establishes challenge", async () => {
             start: BigInt(0),
             end: OPEN_END,
           },
-        },
-        signature: new Uint8Array(),
+        } as TestReadCap,
       },
-    ],
+      [{
+        area: {
+          includedSubspaceId: TestSubspace.Gemma,
+          pathPrefix: [new Uint8Array([1])],
+          timeRange: {
+            start: BigInt(0),
+            end: OPEN_END,
+          },
+        },
+        maxCount: 0,
+        maxSize: BigInt(0),
+      }],
+    ]]),
   });
 
   const messengerBetty = new WgpsMessenger({
@@ -59,22 +75,35 @@ Deno.test("WgpsMessenger establishes challenge", async () => {
       namespace: testSchemeNamespace,
       accessControl: testSchemeAccessControl,
       pai: testSchemePai,
+      path: testSchemePath,
+      subspace: testSchemeSubspace,
     },
-    readAuthorisations: [
+    interests: new Map([[
       {
         capability: {
           namespace: TestNamespace.Family,
           subspace: TestSubspace.Gemma,
-          path: [new Uint8Array([1]), new Uint8Array([2])],
+          path: [new Uint8Array([1])],
           receiver: TestSubspace.Betty,
           time: {
             start: BigInt(0),
             end: OPEN_END,
           },
-        },
-        signature: new Uint8Array(),
+        } as TestReadCap,
       },
-    ],
+      [{
+        area: {
+          includedSubspaceId: TestSubspace.Gemma,
+          pathPrefix: [new Uint8Array([1]), new Uint8Array([2])],
+          timeRange: {
+            start: BigInt(0),
+            end: OPEN_END,
+          },
+        },
+        maxCount: 0,
+        maxSize: BigInt(0),
+      }],
+    ]]),
   });
 
   // @ts-ignore looking at private values is fine

--- a/src/wgps/wgps_messenger.test.ts
+++ b/src/wgps/wgps_messenger.test.ts
@@ -3,12 +3,14 @@ import { transportPairInMemory } from "./transports/in_memory.ts";
 import { WgpsMessenger } from "./wgps_messenger.ts";
 import {
   TestNamespace,
+  testSchemeAccessControl,
   testSchemeNamespace,
   testSchemePai,
   testSchemeSubspaceCap,
   TestSubspace,
 } from "../test/test_schemes.ts";
 import { delay } from "https://deno.land/std@0.202.0/async/delay.ts";
+import { OPEN_END } from "../../deps.ts";
 
 Deno.test("WgpsMessenger establishes challenge", async () => {
   const [alfie, betty] = transportPairInMemory();
@@ -23,9 +25,12 @@ Deno.test("WgpsMessenger establishes challenge", async () => {
     challengeHashLength: 32,
     maxPayloadSizePower: 8,
     transport: alfie,
-    subspaceCapScheme: testSchemeSubspaceCap,
-    namespaceScheme: testSchemeNamespace,
-    paiScheme: testSchemePai,
+    schemes: {
+      subspaceCap: testSchemeSubspaceCap,
+      namespace: testSchemeNamespace,
+      accessControl: testSchemeAccessControl,
+      pai: testSchemePai,
+    },
     readAuthorisations: [
       {
         capability: {
@@ -33,8 +38,12 @@ Deno.test("WgpsMessenger establishes challenge", async () => {
           subspace: TestSubspace.Gemma,
           path: [new Uint8Array([1])],
           receiver: TestSubspace.Alfie,
+          time: {
+            start: BigInt(0),
+            end: OPEN_END,
+          },
         },
-        signature: TestSubspace.Alfie,
+        signature: new Uint8Array(),
       },
     ],
   });
@@ -45,9 +54,12 @@ Deno.test("WgpsMessenger establishes challenge", async () => {
     challengeHashLength: 32,
     maxPayloadSizePower: 8,
     transport: betty,
-    subspaceCapScheme: testSchemeSubspaceCap,
-    namespaceScheme: testSchemeNamespace,
-    paiScheme: testSchemePai,
+    schemes: {
+      subspaceCap: testSchemeSubspaceCap,
+      namespace: testSchemeNamespace,
+      accessControl: testSchemeAccessControl,
+      pai: testSchemePai,
+    },
     readAuthorisations: [
       {
         capability: {
@@ -55,8 +67,12 @@ Deno.test("WgpsMessenger establishes challenge", async () => {
           subspace: TestSubspace.Gemma,
           path: [new Uint8Array([1]), new Uint8Array([2])],
           receiver: TestSubspace.Betty,
+          time: {
+            start: BigInt(0),
+            end: OPEN_END,
+          },
         },
-        signature: TestSubspace.Betty,
+        signature: new Uint8Array(),
       },
     ],
   });


### PR DESCRIPTION
This PR makes the `WgpsMessenger` capable of sending and handling [setup](https://willowprotocol.org/specs/sync/index.html#sync_setup) messages. During setup, two peers exchange (and validate) capabilities, areas of interest, and send static tokens which will be used for exchanging entries later on.

`WgpsMessengerOpts` now includes an `interests`. This is a mapping of `ReadAuthorisation` to many `AreaOfInterest`. After PSI is carried out, the messenger transmits the intersecting capability via `SetupBindReadCapability`, and then all of its corresponding `AreaOfInterest` via `SetupBindAreaOfInterest` messages. When it receives these same messages from the other peer, it validates the capability / area of interest + signatures and binds the data to a corresponding handle.

`HandleStore` now has an async `getEventually` method. This is used for requesting handles which are transmitted by a different channel, and so which may not have been processed or received yet.

`MessageEncoder` and `decodeMessages` have been refactored to allow for encoding/decoding using information _not contained within an encoded message_. For instance, the outer area to decode an encoded relative inner area against.

`PaiFinder` now has a `getIntersectionPrivy` method. This is to retrieve data both sides are privy to (i.e. namespace, outer area) via an intersection.

