### PR TITLE
Add support for reading / writing payloads at an offset + lengthy ent…

### DIFF
--- a/debug/offset_write.ts
+++ b/debug/offset_write.ts
@@ -1,0 +1,14 @@
+const temp = await Deno.makeTempFile({ dir: "./debug" });
+
+const encoded = new TextEncoder().encode("Hello world");
+
+const file = await Deno.open(temp, { write: true });
+
+await file.write(encoded);
+
+await file.seek(6, Deno.SeekMode.Start);
+
+const encoded2 = new TextEncoder().encode("moons");
+
+const writer = file.writable.getWriter();
+await writer.write(encoded2);

--- a/src/store/storage/payload_drivers/filesystem.ts
+++ b/src/store/storage/payload_drivers/filesystem.ts
@@ -1,20 +1,17 @@
 import { ValidationError, WillowError } from "../../../errors.ts";
-import { Payload } from "../../types.ts";
+import { Payload, PayloadScheme } from "../../types.ts";
 import { PayloadDriver } from "../types.ts";
 import { join } from "https://deno.land/std@0.188.0/path/mod.ts";
 import { ensureDir } from "https://deno.land/std@0.188.0/fs/ensure_dir.ts";
 import { move } from "https://deno.land/std@0.188.0/fs/move.ts";
-import { encodeBase32, EncodingScheme } from "../../../../deps.ts";
+import { encodeBase32 } from "../../../../deps.ts";
 
 /** Stores and retrieves payloads from the filesystem. */
 export class PayloadDriverFilesystem<PayloadDigest>
   implements PayloadDriver<PayloadDigest> {
   constructor(
     readonly path: string,
-    readonly payloadScheme: EncodingScheme<PayloadDigest> & {
-      fromBytes: (bytes: Uint8Array | ReadableStream) => Promise<PayloadDigest>;
-      order: (a: PayloadDigest, b: PayloadDigest) => -1 | 0 | 1;
-    },
+    readonly payloadScheme: PayloadScheme<PayloadDigest>,
   ) {
   }
 
@@ -23,9 +20,50 @@ export class PayloadDriverFilesystem<PayloadDigest>
     return encodeBase32(encoded);
   }
 
+  private getPayload(filePath: string): Payload {
+    return {
+      bytes: async (offset) => {
+        if (!offset) {
+          return Deno.readFile(filePath);
+        }
+
+        const stats = await Deno.stat(filePath);
+        const bytes = new Uint8Array(stats.size - offset!);
+
+        const file = await Deno.open(
+          filePath,
+          { read: true },
+        );
+
+        file.seek(offset!, Deno.SeekMode.Start);
+
+        await file.read(bytes);
+
+        file.close();
+
+        return bytes;
+      },
+      stream: async (offset) => {
+        const file = await Deno.open(
+          filePath,
+          { read: true },
+        );
+
+        if (offset) {
+          await file.seek(offset, Deno.SeekMode.Start);
+        }
+
+        return file.readable;
+      },
+      length: async () => {
+        const stats = await Deno.stat(filePath);
+        return BigInt(stats.size);
+      },
+    };
+  }
+
   async get(
     payloadHash: PayloadDigest,
-    opts?: { startOffset?: number | undefined } | undefined,
   ): Promise<Payload | undefined> {
     const filePath = join(this.path, this.getKey(payloadHash));
 
@@ -35,38 +73,7 @@ export class PayloadDriverFilesystem<PayloadDigest>
       return undefined;
     }
 
-    if (opts?.startOffset) {
-      return {
-        bytes: async () => {
-          const stats = await Deno.stat(filePath);
-
-          const bytes = new Uint8Array(stats.size - opts.startOffset!);
-
-          const file = await Deno.open(
-            filePath,
-            { read: true },
-          );
-
-          await Deno.seek(
-            file.rid,
-            opts.startOffset!,
-            Deno.SeekMode.Start,
-          );
-
-          await file.read(bytes);
-
-          file.close();
-
-          return bytes;
-        },
-        stream: new DenoFileReadable(filePath, opts?.startOffset),
-      };
-    }
-
-    return {
-      bytes: () => Deno.readFile(filePath),
-      stream: new DenoFileReadable(filePath),
-    };
+    return this.getPayload(filePath);
   }
 
   async erase(payloadHash: PayloadDigest): Promise<true | ValidationError> {
@@ -82,213 +89,141 @@ export class PayloadDriverFilesystem<PayloadDigest>
     }
   }
 
-  async stage(
-    payload: Uint8Array | ReadableStream<Uint8Array>,
-  ): Promise<
-    {
-      hash: PayloadDigest;
-      length: bigint;
-      commit: () => Promise<Payload>;
-      reject: () => Promise<void>;
-    }
-  > {
-    await this.ensureDir("staging");
-
-    const tempKeyBuf = new Uint8Array(32);
-    crypto.getRandomValues(tempKeyBuf);
-    const tempKey = encodeBase32(tempKeyBuf);
-
-    const stagingPath = join(this.path, "staging", tempKey);
-
+  async set(
+    payload: Uint8Array | AsyncIterable<Uint8Array>,
+  ): Promise<{ digest: PayloadDigest; payload: Payload; length: bigint }> {
     if (payload instanceof Uint8Array) {
-      await Deno.writeFile(stagingPath, payload, { create: true });
-      const hash = await this.payloadScheme.fromBytes(payload);
+      const digest = await this.payloadScheme.fromBytes(payload);
+
+      await this.ensureDir();
+
+      const filePath = join(this.path, this.getKey(digest));
+
+      await Deno.writeFile(filePath, payload, { create: true });
 
       return {
-        hash,
+        digest: digest,
         length: BigInt(payload.byteLength),
-        commit: async () => {
-          await this.ensureDir();
-
-          const filePath = join(this.path, this.getKey(hash));
-          await move(stagingPath, filePath, {
-            overwrite: true,
-          });
-
-          return {
-            bytes: () => Deno.readFile(filePath),
-            stream: new DenoFileReadable(filePath),
-          };
-        },
-        reject: () => {
-          return Deno.remove(stagingPath);
-        },
+        payload: this.getPayload(filePath),
       };
     }
 
     try {
-      await Deno.truncate(stagingPath);
-    } catch {
-      // It's fine.
-    }
+      await this.ensureDir("staging");
 
-    let hash = await this.payloadScheme.fromBytes(new Uint8Array());
-    let length = 0;
+      const tempKeyBuf = new Uint8Array(32);
+      crypto.getRandomValues(tempKeyBuf);
+      const tempKey = encodeBase32(tempKeyBuf);
 
-    try {
+      const stagingPath = join(this.path, "staging", tempKey);
+
+      try {
+        await Deno.truncate(stagingPath);
+      } catch {
+        // It's fine.
+      }
+
       const file = await Deno.open(stagingPath, {
         createNew: true,
         write: true,
       });
 
-      const [forHash, forStorage] = payload.tee();
+      const writer = file.writable.getWriter();
 
-      await Promise.all(
-        [
-          forStorage.pipeTo(file.writable),
-          async () => {
-            hash = await this.payloadScheme.fromBytes(forHash);
-          },
-        ],
-      );
+      for await (const chunk of payload) {
+        await writer.write(chunk);
+      }
+
+      await file.seek(0, Deno.SeekMode.Start);
+
+      const digest = await this.payloadScheme.fromBytes(file.readable);
 
       const stats = await file.stat();
 
-      length = stats.size;
+      await this.ensureDir();
+
+      const filePath = join(this.path, this.getKey(digest));
+      await move(stagingPath, filePath, {
+        overwrite: true,
+      });
+
+      return {
+        digest,
+        length: BigInt(stats.size),
+        payload: this.getPayload(filePath),
+      };
     } catch {
       throw new WillowError("Couldn't write data to the staging path.");
     }
+  }
 
-    return {
-      hash,
-      length: BigInt(length),
-      commit: async () => {
-        await this.ensureDir();
+  async receive(
+    opts: {
+      payload: AsyncIterable<Uint8Array>;
+      offset: number;
+      knownLength: bigint;
+      knownDigest: PayloadDigest;
+    },
+  ): Promise<{ digest: PayloadDigest; length: bigint }> {
+    try {
+      await this.ensureDir();
 
-        const filePath = join(this.path, this.getKey(hash));
-        await move(stagingPath, filePath, {
-          overwrite: true,
-        });
+      const key = this.getKey(opts.knownDigest);
 
-        return {
-          bytes: () => Deno.readFile(filePath),
-          stream: new DenoFileReadable(filePath),
-        };
-      },
-      reject: async () => {
-        try {
-          // We may have gotten an empty stream, in which case no file would have been written.
-          await Deno.lstat(stagingPath);
-          return Deno.remove(stagingPath);
-        } catch {
-          return Promise.resolve();
+      const filePath = join(this.path, key);
+
+      const file = await Deno.open(filePath, {
+        createNew: true,
+        write: true,
+      });
+
+      await file.truncate(opts.offset);
+
+      await file.seek(opts.offset, Deno.SeekMode.Start);
+
+      const writer = file.writable.getWriter();
+
+      let receivedLength = BigInt(0);
+
+      for await (const chunk of opts.payload) {
+        await writer.write(chunk);
+
+        receivedLength += BigInt(chunk.byteLength);
+
+        if (receivedLength >= opts.knownLength) {
+          break;
         }
-      },
-    };
+      }
+
+      await file.seek(0, Deno.SeekMode.Start);
+
+      const digest = await this.payloadScheme.fromBytes(file.readable);
+
+      const stats = await file.stat();
+
+      const length = stats.size;
+
+      return {
+        digest,
+        length: BigInt(length),
+      };
+    } catch {
+      throw new WillowError("Couldn't write data to the filesystem.");
+    }
+  }
+
+  async length(payloadHash: PayloadDigest): Promise<bigint> {
+    const filePath = join(this.path, this.getKey(payloadHash));
+
+    try {
+      const stats = await Deno.lstat(filePath);
+      return BigInt(stats.size);
+    } catch {
+      return BigInt(0);
+    }
   }
 
   private ensureDir(...args: string[]) {
     return ensureDir(join(this.path, ...args));
-  }
-}
-
-class DenoFileReadable implements ReadableStream<Uint8Array> {
-  private path: string;
-  private offset: number | undefined;
-  private stream: ReadableStream<Uint8Array> | undefined;
-
-  constructor(path: string, offset?: number) {
-    this.path = path;
-    this.offset = offset;
-  }
-
-  private initiateStream() {
-    const file = Deno.openSync(this.path);
-
-    if (this.offset) {
-      file.seek(this.offset, Deno.SeekMode.Start);
-    }
-
-    this.stream = file.readable;
-  }
-
-  get values() {
-    if (!this.stream) {
-      this.initiateStream();
-    }
-
-    return this.stream!.values;
-  }
-
-  get locked() {
-    if (this.stream) {
-      return this.stream.locked;
-    }
-
-    return false;
-  }
-
-  cancel() {
-    if (this.stream) {
-      return this.stream.cancel();
-    }
-
-    return Promise.resolve();
-  }
-
-  getReader(options: { mode: "byob" }): ReadableStreamBYOBReader;
-  getReader(
-    options?: { mode?: undefined } | undefined,
-  ): ReadableStreamDefaultReader<Uint8Array>;
-  getReader(
-    options?: unknown,
-  ): ReadableStreamBYOBReader | ReadableStreamDefaultReader<Uint8Array> {
-    if (!this.stream) {
-      this.initiateStream();
-    }
-
-    /* @ts-ignore */
-    return this.stream!.getReader(options);
-  }
-
-  pipeThrough<T>(
-    transform: {
-      writable: WritableStream<Uint8Array>;
-      readable: ReadableStream<T>;
-    },
-    options?: PipeOptions | undefined,
-  ): ReadableStream<T> {
-    if (!this.stream) {
-      this.initiateStream();
-    }
-
-    return this.stream!.pipeThrough(transform, options);
-  }
-
-  pipeTo(
-    dest: WritableStream<Uint8Array>,
-    options?: PipeOptions | undefined,
-  ): Promise<void> {
-    if (!this.stream) {
-      this.initiateStream();
-    }
-
-    return this.stream!.pipeTo(dest, options);
-  }
-
-  tee(): [ReadableStream<Uint8Array>, ReadableStream<Uint8Array>] {
-    if (!this.stream) {
-      this.initiateStream();
-    }
-
-    return this.stream!.tee();
-  }
-
-  [Symbol.asyncIterator]() {
-    if (!this.stream) {
-      this.initiateStream();
-    }
-
-    return this.stream![Symbol.asyncIterator]();
   }
 }

--- a/src/store/storage/storage_3d/types.ts
+++ b/src/store/storage/storage_3d/types.ts
@@ -27,6 +27,11 @@ export interface Storage3d<
     authTokenDigest: PayloadDigest;
   }): Promise<void>;
 
+  updateAvailablePayload(
+    subspace: SubspaceId,
+    path: Path,
+  ): Promise<boolean>;
+
   remove(
     entry: Entry<NamespaceId, SubspaceId, PayloadDigest>,
   ): Promise<boolean>;

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -469,7 +469,7 @@ Deno.test("Store.ingestPayload", async (test) => {
       path: [new Uint8Array([0])],
       subspace: TestSubspace.Gemma,
       timestamp: BigInt(0),
-    }, new Uint8Array());
+    }, new Blob([new Uint8Array()]).stream());
 
     assert(res.kind === "failure");
     assert(res.reason === "no_entry");
@@ -499,7 +499,7 @@ Deno.test("Store.ingestPayload", async (test) => {
       path: res.entry.path,
       subspace: res.entry.subspaceId,
       timestamp: res.entry.timestamp,
-    }, payload);
+    }, new Blob([new Uint8Array()]).stream());
 
     assert(res3.kind === "success");
 
@@ -507,7 +507,7 @@ Deno.test("Store.ingestPayload", async (test) => {
       path: res.entry.path,
       subspace: res.entry.subspaceId,
       timestamp: res.entry.timestamp,
-    }, payload);
+    }, new Blob([payload]).stream());
 
     assert(res4.kind === "no_op");
   });
@@ -536,10 +536,10 @@ Deno.test("Store.ingestPayload", async (test) => {
       path: res.entry.path,
       subspace: res.entry.subspaceId,
       timestamp: res.entry.timestamp,
-    }, new Uint8Array(32));
+    }, new Blob([new Uint8Array(32)]).stream());
 
     assert(res3.kind === "failure");
-    assert(res3.reason === "mismatched_hash");
+    assert(res3.reason === "data_mismatch");
   });
 
   await test.step("ingest if everything is valid", async () => {
@@ -566,7 +566,7 @@ Deno.test("Store.ingestPayload", async (test) => {
       path: res.entry.path,
       subspace: res.entry.subspaceId,
       timestamp: res.entry.timestamp,
-    }, payload);
+    }, new Blob([payload]).stream());
 
     assert(res3.kind === "success");
 

--- a/src/test/test_schemes.ts
+++ b/src/test/test_schemes.ts
@@ -388,15 +388,19 @@ export const testSchemeFingerprint: FingerprintScheme<
   Uint8Array
 > = {
   neutral: new Uint8Array(32),
-  async fingerprintSingleton(entry) {
+  async fingerprintSingleton(lengthy) {
     const encodedEntry = encodeEntry({
       namespaceScheme: testSchemeNamespace,
       subspaceScheme: testSchemeSubspace,
       pathScheme: testSchemePath,
       payloadScheme: testSchemePayload,
-    }, entry);
+    }, lengthy.entry);
 
-    return new Uint8Array(await crypto.subtle.digest("SHA-256", encodedEntry));
+    const lengthEnc = bigintToBytes(lengthy.available);
+
+    return new Uint8Array(
+      await crypto.subtle.digest("SHA-256", concat(encodedEntry, lengthEnc)),
+    );
   },
   fingerprintCombine(a, b) {
     const bytes = new Uint8Array(32);


### PR DESCRIPTION
Closes #10 

- Refactors `Payload` so that an offset can be specified when retrieving bytes or a stream, and adds a `length` function.
- Refactors `PayloadDriver` so that `stage` is split into `set` (for when we are creating a new entry) and `receive` (when we are accepting bytes for an existing entry).
- References to payloads are now counted so that they are only deleted if no references to them remain.
- TripleStorage now fingerprints using `LengthyEntry` instead of entry.