### PR TITLE
fix: Make PayloadDriverIndexedDB use different DB

### DIFF
--- a/src/store/storage/payload_drivers/indexeddb.ts
+++ b/src/store/storage/payload_drivers/indexeddb.ts
@@ -14,7 +14,7 @@ export class PayloadDriverIndexedDb<PayloadDigest>
 
   constructor(readonly payloadScheme: PayloadScheme<PayloadDigest>) {
     const request = ((window as any).indexedDB as IDBFactory).open(
-      `willow`,
+      `willow_payloads`,
       1,
     );
 


### PR DESCRIPTION
Both the KV and Payload drivers for IndexedDB used a database named ‘willow’ with the same version number. This meant that when either driver opened after the other, they would not detect that any DB upgrade would be needed, and fail to create their own necessary object stores. 

I’ve fixed this by making the payload driver open a database named `willow_payloads`.

Thanks to @Vicente015 for identifying the bug!