### PR TITLE
Add ID param to IndexedDB drivers

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -86,6 +86,7 @@
       "@std/io@0.224.0": {
         "integrity": "0aff885d21d829c050b8a08b1d71b54aed5841aecf227f8d77e99ec529a11e8e",
         "dependencies": [
+          "jsr:@std/assert@^0.224.0",
           "jsr:@std/bytes@^0.224.0"
         ]
       },

--- a/src/store/storage/kv/kv.test.ts
+++ b/src/store/storage/kv/kv.test.ts
@@ -32,7 +32,7 @@ Deno.test("Test deno kv store", async (t) => {
 });
 
 Deno.test("Test IndexedDB kv store", async (t) => {
-  const store = new KvDriverIndexedDB();
+  const store = new KvDriverIndexedDB("test");
   await testKvStore(t, store);
 });
 
@@ -940,7 +940,7 @@ Deno.test({
       key: 2,
     }];
 
-    const indexDbKv = new KvDriverIndexedDB();
+    const indexDbKv = new KvDriverIndexedDB("test");
     await runTestCase(ops, queries, indexDbKv);
     await indexDbKv.clear();
     // Let IndexedDB polyfill timers run their course.
@@ -967,7 +967,7 @@ Deno.test({
       },
     ];
 
-    const indexDbKv = new KvDriverIndexedDB();
+    const indexDbKv = new KvDriverIndexedDB("test");
     await runTestCase(ops, queries, indexDbKv);
     await indexDbKv.clear();
     // Let IndexedDB polyfill timers run their course.
@@ -1048,7 +1048,7 @@ Deno.test({
       },
     ];
 
-    const indexDbKv = new KvDriverIndexedDB();
+    const indexDbKv = new KvDriverIndexedDB("test");
     await runTestCase(ops, queries, indexDbKv);
     await indexDbKv.clear();
     // Let IndexedDB polyfill timers run their course.
@@ -1117,7 +1117,7 @@ Deno.test({
       },
     ];
 
-    const indexDbKv = new KvDriverIndexedDB();
+    const indexDbKv = new KvDriverIndexedDB("test");
     await runTestCase(ops, queries, indexDbKv);
     await indexDbKv.clear();
     // Let IndexedDB polyfill timers run their course.
@@ -1143,7 +1143,7 @@ Deno.test.ignore({
           queries.push(randomQuery(numKeys));
         }
 
-        const idbKv = new KvDriverIndexedDB();
+        const idbKv = new KvDriverIndexedDB("test");
         await runTestCase(ops, queries, idbKv);
 
         await idbKv.clear();
@@ -1167,7 +1167,7 @@ Deno.test.ignore({
           queries.push(randomQuery(numKeys));
         }
 
-        const idbKv = new KvDriverIndexedDB();
+        const idbKv = new KvDriverIndexedDB("test");
         await runTestCase(ops, queries, idbKv);
 
         await idbKv.clear();

--- a/src/store/storage/kv/kv_driver_indexeddb.ts
+++ b/src/store/storage/kv/kv_driver_indexeddb.ts
@@ -17,9 +17,9 @@ const END_LIST = Symbol("end_list");
 export class KvDriverIndexedDB implements KvDriver {
   private db = Promise.withResolvers<IDBDatabase>();
 
-  constructor() {
+  constructor(id: string) {
     const request = ((window as any).indexedDB as IDBFactory).open(
-      `willow`,
+      `willow_${id}`,
       1,
     );
 

--- a/src/store/storage/payload_drivers/indexeddb.ts
+++ b/src/store/storage/payload_drivers/indexeddb.ts
@@ -12,9 +12,12 @@ export class PayloadDriverIndexedDb<PayloadDigest>
   implements PayloadDriver<PayloadDigest> {
   private db = Promise.withResolvers<IDBDatabase>();
 
-  constructor(readonly payloadScheme: PayloadScheme<PayloadDigest>) {
+  constructor(
+    id: string,
+    readonly payloadScheme: PayloadScheme<PayloadDigest>,
+  ) {
     const request = ((window as any).indexedDB as IDBFactory).open(
-      `willow_payloads`,
+      `willow_payloads_${id}`,
       1,
     );
 

--- a/src/store/storage/payload_drivers/payload_driver.test.ts
+++ b/src/store/storage/payload_drivers/payload_driver.test.ts
@@ -20,7 +20,7 @@ testPayloadDriver("Filesystem", () => {
 });
 
 testPayloadDriver("IndexedDB", () => {
-  return new PayloadDriverIndexedDb(testSchemePayload);
+  return new PayloadDriverIndexedDb('test', testSchemePayload);
 }, () => Promise.resolve());
 
 function testPayloadDriver(

--- a/src/store/storage/storage_3d/types.ts
+++ b/src/store/storage/storage_3d/types.ts
@@ -1,4 +1,9 @@
-import type { AreaOfInterest, Entry, Path, Range3d } from "@earthstar/willow-utils";
+import type {
+  AreaOfInterest,
+  Entry,
+  Path,
+  Range3d,
+} from "@earthstar/willow-utils";
 import type { QueryOrder } from "../../types.ts";
 
 /** A type exclusive to this implementation, used to make our lives easier. */

--- a/src/store/storage/summarisable_storage/linear_summarisable_storage.ts
+++ b/src/store/storage/summarisable_storage/linear_summarisable_storage.ts
@@ -5,7 +5,11 @@
  */
 
 import type { KvDriver, KvKey } from "../kv/types.ts";
-import { combineMonoid, type LiftingMonoid, sizeMonoid } from "./lifting_monoid.ts";
+import {
+  combineMonoid,
+  type LiftingMonoid,
+  sizeMonoid,
+} from "./lifting_monoid.ts";
 import type { SummarisableStorage } from "./types.ts";
 
 export type LinearStorageOpts<

--- a/src/wgps/cap_finder.ts
+++ b/src/wgps/cap_finder.ts
@@ -3,7 +3,11 @@ import type { HandleStore } from "./handle_store.ts";
 import type { AccessControlScheme } from "./types.ts";
 import { WillowError } from "../errors.ts";
 import { encodeBase64 } from "@std/encoding/base64";
-import { type Entry, entryPosition, isIncludedArea } from "@earthstar/willow-utils";
+import {
+  type Entry,
+  entryPosition,
+  isIncludedArea,
+} from "@earthstar/willow-utils";
 
 /** Helps you get capabilities for given entries */
 export class CapFinder<


### PR DESCRIPTION
IndexedDB drivers were _not_ namespaced, so any setup which used more than a single namespace would break.