### PR TITLE
IndexedDB fixes

### DIFF
--- a/src/store/storage/kv/kv_driver_indexeddb.ts
+++ b/src/store/storage/kv/kv_driver_indexeddb.ts
@@ -325,12 +325,7 @@ function selectorToIdbBound({ start, end, prefix }: {
       actualPackedStart && actualPackedEnd &&
       equalsBytes(actualPackedStart, actualPackedEnd)
     ) {
-      return IDBKeyRange.bound(
-        actualPackedStart,
-        actualPackedEnd,
-        false,
-        false,
-      );
+      return "notMatchingAnything";
     }
 
     return IDBKeyRange.bound(

--- a/src/store/storage/kv/prefixed_driver.ts
+++ b/src/store/storage/kv/prefixed_driver.ts
@@ -91,7 +91,9 @@ export class PrefixedDriver implements KvDriver {
       delete(key) {
         return batch.delete([...prefix, ...key]);
       },
-      commit: batch.commit,
+      commit() {
+        return batch.commit();
+      },
     };
   }
 }


### PR DESCRIPTION
- Calls to `KvBatch.commit` were not being bound properly when used in a prefixed driver.
- Calling a cursor with `prevunique` / `nextunique` caused problems in Safari because these are only allowed on indexes. We don't need it, so just use `prev` / `next`, respectively.
- An invalid IndexedDB bound was being created in certain list operations with a prefix supplied. My fix is to use a closed upper bound if the start and end of the bound are the same.