### PR TITLE
Add some supporting stuff for future plum trees

### DIFF
--- a/src/store/events.ts
+++ b/src/store/events.ts
@@ -36,16 +36,19 @@ export class EntryIngestEvent<
   {
     entry: Entry<NamespacePublicKey, SubspacePublicKey, PayloadDigest>;
     authToken: AuthorisationToken;
+    externalSourceId?: string;
   }
 > {
   constructor(
     entry: Entry<NamespacePublicKey, SubspacePublicKey, PayloadDigest>,
     authToken: AuthorisationToken,
+    externalSourceId?: string,
   ) {
     super("entryingest", {
       detail: {
         entry,
         authToken,
+        externalSourceId,
       },
     });
   }
@@ -61,17 +64,43 @@ export class PayloadIngestEvent<
   entry: Entry<NamespacePublicKey, SubspacePublicKey, PayloadDigest>;
   authToken: AuthorisationToken;
   payload: Payload;
+  externalSourceId?: string;
 }> {
   constructor(
     entry: Entry<NamespacePublicKey, SubspacePublicKey, PayloadDigest>,
     authToken: AuthorisationToken,
     payload: Payload,
+    externalSourceId?: string,
   ) {
     super("payloadingest", {
       detail: {
         entry,
         authToken,
         payload,
+        externalSourceId,
+      },
+    });
+  }
+}
+
+/** Emitted after a {@linkcode Store} attempts to ingest a payload, but already had it. */
+export class PayloadNoOpEvent<
+  NamespacePublicKey,
+  SubspacePublicKey,
+  PayloadDigest,
+  AuthorisationToken,
+> extends CustomEvent<{
+  entry: Entry<NamespacePublicKey, SubspacePublicKey, PayloadDigest>;
+  externalSourceId?: string;
+}> {
+  constructor(
+    entry: Entry<NamespacePublicKey, SubspacePublicKey, PayloadDigest>,
+    externalSourceId?: string,
+  ) {
+    super("payloadnoop", {
+      detail: {
+        entry,
+        externalSourceId,
       },
     });
   }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -179,6 +179,8 @@ export type IngestEventFailure = {
 export type IngestEventNoOp = {
   kind: "no_op";
   reason: "obsolete_from_same_subspace" | "newer_prefix_found";
+  /** An ID representing the source of this ingested entry. */
+  externalSourceId?: string;
 };
 
 /** Emitted after a successuful entry ingestion. */
@@ -261,11 +263,15 @@ export type IngestPayloadEventFailure = {
 export type IngestPayloadEventNoOp = {
   kind: "no_op";
   reason: "already_have_it";
+  /** An ID representing the source of this ingested entry. */
+  externalSourceId?: string;
 };
 
 /** Emitted after the succesful ingestion of a payload. */
 export type IngestPayloadEventSuccess = {
   kind: "success";
+  /** An ID representing the source of this ingested entry. */
+  externalSourceId?: string;
 };
 
 /** Emitted after payload entry. */

--- a/src/wgps/data/payload_ingester.ts
+++ b/src/wgps/data/payload_ingester.ts
@@ -44,6 +44,8 @@ export class PayloadIngester<
     | Entry<NamespaceId, SubspaceId, PayloadDigest>
     | null = null;
 
+  private id: string;
+
   constructor(opts: {
     getStore: GetStoreFn<
       Prefingerprint,
@@ -58,8 +60,11 @@ export class PayloadIngester<
       bytes: Uint8Array,
       entryLength: bigint,
     ) => Uint8Array;
+    id: string;
   }) {
     this.processReceivedPayload = opts.processReceivedPayload;
+
+    this.id = opts.id;
 
     onAsyncIterate(this.events, async (event) => {
       if (event === CANCELLATION) {
@@ -105,7 +110,7 @@ export class PayloadIngester<
             path: entry.path,
             subspace: entry.subspaceId,
             timestamp: entry.timestamp,
-          }, new CancellableIngestion(fifo));
+          }, new CancellableIngestion(fifo), false, 0, this.id);
 
           this.currentIngestion = {
             kind: "active",

--- a/src/wgps/static_token_store.ts
+++ b/src/wgps/static_token_store.ts
@@ -1,0 +1,49 @@
+import { encodeBase64 } from "@std/encoding/base64";
+import { HandleStore } from "./handle_store.ts";
+import { WillowError } from "../errors.ts";
+import FIFO from "@korkje/fifo";
+
+/** Maps static tokens to handles and vice versa. `boundStaticTokens` needs to be sent to the peer. */
+export class StaticTokenStore<StaticToken> {
+  private byHandle = new HandleStore<StaticToken>();
+  private byValue = new Map<string, bigint>();
+
+  private valueEncoder: (value: StaticToken) => Uint8Array;
+  private boundTokensQueue = new FIFO<StaticToken>();
+
+  constructor(valueEncoder: (value: StaticToken) => Uint8Array) {
+    this.valueEncoder = valueEncoder;
+  }
+
+  getByValue(
+    value: StaticToken,
+  ): bigint {
+    const encoded = this.valueEncoder(value);
+    const base64 = encodeBase64(encoded);
+
+    const existingHandle = this.byValue.get(base64);
+
+    if (existingHandle !== undefined) {
+      const canUse = this.byHandle.canUse(existingHandle);
+
+      if (!canUse) {
+        throw new WillowError("Could not use a static token handle");
+      }
+
+      return existingHandle;
+    }
+
+    const newHandle = this.byHandle.bind(value);
+    this.byValue.set(base64, newHandle);
+
+    this.boundTokensQueue.push(value);
+
+    return newHandle;
+  }
+
+  *boundStaticTokens() {
+    for (const boundToken of this.boundTokensQueue) {
+      yield boundToken;
+    }
+  }
+}

--- a/src/wgps/wgps_messenger.ts
+++ b/src/wgps/wgps_messenger.ts
@@ -189,6 +189,8 @@ export class WgpsMessenger<
 > {
   private closed = false;
 
+  id: string;
+
   private interests: Map<
     ReadAuthorisation<ReadCapability, SubspaceCapability>,
     AreaOfInterest<SubspaceId>[]
@@ -436,6 +438,9 @@ export class WgpsMessenger<
       AuthorisationOpts
     >,
   ) {
+    // TODO think of a better naming scheme (maybe include protocol)
+    this.id = String(Math.floor(Math.random() * (1 << 30)));
+
     if (opts.maxPayloadSizePower < 0 || opts.maxPayloadSizePower > 64) {
       throw new ValidationError(
         "maxPayloadSizePower must be a natural number less than or equal to 64",
@@ -513,6 +518,7 @@ export class WgpsMessenger<
     this.reconciliationPayloadIngester = new PayloadIngester({
       getStore: this.getStore,
       processReceivedPayload: opts.processReceivedPayload,
+      id: this.id,
     });
 
     // Data
@@ -546,6 +552,7 @@ export class WgpsMessenger<
     this.dataPayloadIngester = new PayloadIngester({
       getStore: this.getStore,
       processReceivedPayload: opts.processReceivedPayload,
+      id: this.id,
     });
 
     this.onMessage = opts.onMessage;
@@ -1428,7 +1435,7 @@ export class WgpsMessenger<
         const result = await store.ingestEntry(
           message.entry.entry,
           authToken,
-          "TODO_DEFINE_THIS_WHEN_PLUMTREES_GROW",
+          this.id,
         );
 
         if (result.kind === "failure") {


### PR DESCRIPTION
* some random WGPS IDs for now
* store events forward those IDs
* new store EventPayloadNoOp if a peer tried to give use a payload we already have (so we can set that peer to lazy in a plum tree later)
* metadata to change eagerness
* sendEntry to explicitly send an entry (and a test for that)

Currently, there is WGPS' `this.reconcilerMap` which maps intersections (based on the peers' aoi handles) to a `Reconciler`. `isEager` could be squeezed in there, renaming the map to `intersectionMap` or something, which hosts both the `Reconciler` and `isEager`. Not sure what's cleaner: keeping them together under one Intersection, or have them separated because they don't actually share anything. Also in pre-willow earthstar it seems the live syncing was done after reconciliation. However, I think it needs to be done at the same time, for the case when an entry gets inserted during reconciliation.

Down the road we also need an efficient way of finding intersections based on an entry's position for the requested eagerness.

For the plum tree manager I thought of the following architecture: a plum tree manager that the user adds WGPS to. WGPS dispatches 'intersection' events. For each intersection the manager either creates a new plum tree or gets a running one. This plum tree listens to the intersection.namespace's store for PayloadEvents, and forwards entries/changes eagerness with the API of this PR. So the WGPS doesn't need to know about `PlumtreeManager` and can run without one.

Any oversights/things I should change? :-)