### PR TITLE
Refactor: Improve Store events type-safety

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -16,6 +16,7 @@
   },
   "unstable": ["kv"],
   "imports": {
+    "@derzade/typescript-event-target": "jsr:@derzade/typescript-event-target@^1.1.1",
     "@earthstar/willow-utils": "jsr:@earthstar/willow-utils@^2.0.0",
     "@korkje/fifo": "jsr:@korkje/fifo@^0.2.4",
     "@luca/esbuild-deno-loader": "jsr:@luca/esbuild-deno-loader@^0.10.3",

--- a/deno.lock
+++ b/deno.lock
@@ -5,6 +5,8 @@
       "jsr:@derzade/typescript-event-target@^1.1.1": "jsr:@derzade/typescript-event-target@1.1.1",
       "jsr:@earthstar/willow-utils@^2.0.0": "jsr:@earthstar/willow-utils@2.0.1",
       "jsr:@korkje/fifo@^0.2.4": "jsr:@korkje/fifo@0.2.4",
+      "jsr:@luca/esbuild-deno-loader@^0.10.3": "jsr:@luca/esbuild-deno-loader@0.10.3",
+      "jsr:@std/assert@^0.213.1": "jsr:@std/assert@0.213.1",
       "jsr:@std/assert@^0.224.0": "jsr:@std/assert@0.224.0",
       "jsr:@std/assert@^0.225.2": "jsr:@std/assert@0.225.3",
       "jsr:@std/assert@^0.226.0": "jsr:@std/assert@0.226.0",
@@ -15,15 +17,20 @@
       "jsr:@std/collections@^0.224.2": "jsr:@std/collections@0.224.2",
       "jsr:@std/crypto@^0.224.0": "jsr:@std/crypto@0.224.0",
       "jsr:@std/data-structures@^0.224.0": "jsr:@std/data-structures@0.224.1",
+      "jsr:@std/encoding@0.213": "jsr:@std/encoding@0.213.1",
       "jsr:@std/encoding@^0.224.0": "jsr:@std/encoding@0.224.3",
       "jsr:@std/encoding@^0.224.1": "jsr:@std/encoding@0.224.3",
       "jsr:@std/fs@^0.229.1": "jsr:@std/fs@0.229.3",
       "jsr:@std/internal@^1.0.0": "jsr:@std/internal@1.0.5",
       "jsr:@std/io@^0.224.1": "jsr:@std/io@0.224.9",
+      "jsr:@std/jsonc@0.213": "jsr:@std/jsonc@0.213.1",
+      "jsr:@std/path@0.213": "jsr:@std/path@0.213.1",
       "jsr:@std/path@1.0.0-rc.1": "jsr:@std/path@1.0.0-rc.1",
       "jsr:@std/path@^0.225.1": "jsr:@std/path@0.225.2",
       "jsr:@std/streams@^0.224.0": "jsr:@std/streams@0.224.5",
-      "npm:@noble/curves": "npm:@noble/curves@1.4.0"
+      "npm:@noble/curves": "npm:@noble/curves@1.4.0",
+      "npm:esbuild": "npm:esbuild@0.21.5",
+      "npm:esbuild@^0.21.3": "npm:esbuild@0.21.5"
     },
     "jsr": {
       "@derzade/typescript-event-target@1.1.1": {
@@ -37,6 +44,17 @@
       },
       "@korkje/fifo@0.2.4": {
         "integrity": "cd8ff3edf686dcfd0b26d4774705d6a080312afb666d93f3a90d3fc808df41ba"
+      },
+      "@luca/esbuild-deno-loader@0.10.3": {
+        "integrity": "32fc93f7e7f78060234fd5929a740668aab1c742b808c6048b57f9aaea514921",
+        "dependencies": [
+          "jsr:@std/encoding@0.213",
+          "jsr:@std/jsonc@0.213",
+          "jsr:@std/path@0.213"
+        ]
+      },
+      "@std/assert@0.213.1": {
+        "integrity": "24c28178b30c8e0782c18e8e94ea72b16282207569cdd10ffb9d1d26f2edebfe"
       },
       "@std/assert@0.224.0": {
         "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f"
@@ -72,6 +90,9 @@
       "@std/data-structures@0.224.1": {
         "integrity": "266365f90014e5c52bccf1eadd65f7782a2af2c84e4052ef8316698a3572cac3"
       },
+      "@std/encoding@0.213.1": {
+        "integrity": "fcbb6928713dde941a18ca5db88ca1544d0755ec8fb20fe61e2dc8144b390c62"
+      },
       "@std/encoding@0.224.3": {
         "integrity": "5e861b6d81be5359fad4155e591acf17c0207b595112d1840998bb9f476dbdaf"
       },
@@ -88,6 +109,18 @@
         "integrity": "4414664b6926f665102e73c969cfda06d2c4c59bd5d0c603fd4f1b1c840d6ee3",
         "dependencies": [
           "jsr:@std/bytes@^1.0.2"
+        ]
+      },
+      "@std/jsonc@0.213.1": {
+        "integrity": "5578f21aa583b7eb7317eed077ffcde47b294f1056bdbb9aacec407758637bfe",
+        "dependencies": [
+          "jsr:@std/assert@^0.213.1"
+        ]
+      },
+      "@std/path@0.213.1": {
+        "integrity": "f187bf278a172752e02fcbacf6bd78a335ed320d080a7ed3a5a59c3e88abc673",
+        "dependencies": [
+          "jsr:@std/assert@^0.213.1"
         ]
       },
       "@std/path@0.225.2": {
@@ -108,6 +141,98 @@
       }
     },
     "npm": {
+      "@esbuild/aix-ppc64@0.21.5": {
+        "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+        "dependencies": {}
+      },
+      "@esbuild/android-arm64@0.21.5": {
+        "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+        "dependencies": {}
+      },
+      "@esbuild/android-arm@0.21.5": {
+        "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+        "dependencies": {}
+      },
+      "@esbuild/android-x64@0.21.5": {
+        "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+        "dependencies": {}
+      },
+      "@esbuild/darwin-arm64@0.21.5": {
+        "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+        "dependencies": {}
+      },
+      "@esbuild/darwin-x64@0.21.5": {
+        "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+        "dependencies": {}
+      },
+      "@esbuild/freebsd-arm64@0.21.5": {
+        "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+        "dependencies": {}
+      },
+      "@esbuild/freebsd-x64@0.21.5": {
+        "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-arm64@0.21.5": {
+        "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-arm@0.21.5": {
+        "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-ia32@0.21.5": {
+        "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-loong64@0.21.5": {
+        "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-mips64el@0.21.5": {
+        "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-ppc64@0.21.5": {
+        "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-riscv64@0.21.5": {
+        "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-s390x@0.21.5": {
+        "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+        "dependencies": {}
+      },
+      "@esbuild/linux-x64@0.21.5": {
+        "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+        "dependencies": {}
+      },
+      "@esbuild/netbsd-x64@0.21.5": {
+        "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+        "dependencies": {}
+      },
+      "@esbuild/openbsd-x64@0.21.5": {
+        "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+        "dependencies": {}
+      },
+      "@esbuild/sunos-x64@0.21.5": {
+        "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+        "dependencies": {}
+      },
+      "@esbuild/win32-arm64@0.21.5": {
+        "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+        "dependencies": {}
+      },
+      "@esbuild/win32-ia32@0.21.5": {
+        "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+        "dependencies": {}
+      },
+      "@esbuild/win32-x64@0.21.5": {
+        "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+        "dependencies": {}
+      },
       "@noble/curves@1.4.0": {
         "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
         "dependencies": {
@@ -117,6 +242,34 @@
       "@noble/hashes@1.4.0": {
         "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
         "dependencies": {}
+      },
+      "esbuild@0.21.5": {
+        "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+        "dependencies": {
+          "@esbuild/aix-ppc64": "@esbuild/aix-ppc64@0.21.5",
+          "@esbuild/android-arm": "@esbuild/android-arm@0.21.5",
+          "@esbuild/android-arm64": "@esbuild/android-arm64@0.21.5",
+          "@esbuild/android-x64": "@esbuild/android-x64@0.21.5",
+          "@esbuild/darwin-arm64": "@esbuild/darwin-arm64@0.21.5",
+          "@esbuild/darwin-x64": "@esbuild/darwin-x64@0.21.5",
+          "@esbuild/freebsd-arm64": "@esbuild/freebsd-arm64@0.21.5",
+          "@esbuild/freebsd-x64": "@esbuild/freebsd-x64@0.21.5",
+          "@esbuild/linux-arm": "@esbuild/linux-arm@0.21.5",
+          "@esbuild/linux-arm64": "@esbuild/linux-arm64@0.21.5",
+          "@esbuild/linux-ia32": "@esbuild/linux-ia32@0.21.5",
+          "@esbuild/linux-loong64": "@esbuild/linux-loong64@0.21.5",
+          "@esbuild/linux-mips64el": "@esbuild/linux-mips64el@0.21.5",
+          "@esbuild/linux-ppc64": "@esbuild/linux-ppc64@0.21.5",
+          "@esbuild/linux-riscv64": "@esbuild/linux-riscv64@0.21.5",
+          "@esbuild/linux-s390x": "@esbuild/linux-s390x@0.21.5",
+          "@esbuild/linux-x64": "@esbuild/linux-x64@0.21.5",
+          "@esbuild/netbsd-x64": "@esbuild/netbsd-x64@0.21.5",
+          "@esbuild/openbsd-x64": "@esbuild/openbsd-x64@0.21.5",
+          "@esbuild/sunos-x64": "@esbuild/sunos-x64@0.21.5",
+          "@esbuild/win32-arm64": "@esbuild/win32-arm64@0.21.5",
+          "@esbuild/win32-ia32": "@esbuild/win32-ia32@0.21.5",
+          "@esbuild/win32-x64": "@esbuild/win32-x64@0.21.5"
+        }
       }
     }
   },

--- a/deno.lock
+++ b/deno.lock
@@ -1,121 +1,257 @@
 {
-  "version": "3",
-  "packages": {
-    "specifiers": {
-      "jsr:@earthstar/willow-utils@^2.0.0": "jsr:@earthstar/willow-utils@2.0.0",
-      "jsr:@korkje/fifo@^0.2.4": "jsr:@korkje/fifo@0.2.4",
-      "jsr:@std/assert@^0.224.0": "jsr:@std/assert@0.224.0",
-      "jsr:@std/assert@^0.225.2": "jsr:@std/assert@0.225.3",
-      "jsr:@std/assert@^0.225.3": "jsr:@std/assert@0.225.3",
-      "jsr:@std/assert@^0.226.0": "jsr:@std/assert@0.226.0",
-      "jsr:@std/async@^0.224.0": "jsr:@std/async@0.224.1",
-      "jsr:@std/bytes@^0.224.0": "jsr:@std/bytes@0.224.0",
-      "jsr:@std/bytes@^1.0.0-rc.3": "jsr:@std/bytes@1.0.0-rc.3",
-      "jsr:@std/collections@^0.224.2": "jsr:@std/collections@0.224.2",
-      "jsr:@std/crypto@^0.224.0": "jsr:@std/crypto@0.224.0",
-      "jsr:@std/data-structures@^0.224.0": "jsr:@std/data-structures@0.224.1",
-      "jsr:@std/encoding@^0.224.0": "jsr:@std/encoding@0.224.3",
-      "jsr:@std/encoding@^0.224.1": "jsr:@std/encoding@0.224.3",
-      "jsr:@std/fs@^0.229.1": "jsr:@std/fs@0.229.1",
-      "jsr:@std/internal@^1.0.0": "jsr:@std/internal@1.0.0",
-      "jsr:@std/io@^0.224.0": "jsr:@std/io@0.224.0",
-      "jsr:@std/path@^0.225.1": "jsr:@std/path@0.225.2",
-      "jsr:@std/streams@^0.224.0": "jsr:@std/streams@0.224.3",
-      "npm:@noble/curves": "npm:@noble/curves@1.4.0"
+  "version": "4",
+  "specifiers": {
+    "jsr:@derzade/typescript-event-target@^1.1.1": "1.1.1",
+    "jsr:@earthstar/willow-utils@2": "2.0.0",
+    "jsr:@korkje/fifo@~0.2.4": "0.2.4",
+    "jsr:@luca/esbuild-deno-loader@~0.10.3": "0.10.3",
+    "jsr:@std/assert@0.224": "0.224.0",
+    "jsr:@std/assert@0.226": "0.226.0",
+    "jsr:@std/assert@~0.213.1": "0.213.1",
+    "jsr:@std/assert@~0.225.2": "0.225.3",
+    "jsr:@std/assert@~0.225.3": "0.225.3",
+    "jsr:@std/async@0.224": "0.224.1",
+    "jsr:@std/bytes@0.224": "0.224.0",
+    "jsr:@std/bytes@^1.0.0-rc.3": "1.0.0-rc.3",
+    "jsr:@std/collections@~0.224.2": "0.224.2",
+    "jsr:@std/crypto@0.224": "0.224.0",
+    "jsr:@std/data-structures@0.224": "0.224.1",
+    "jsr:@std/encoding@0.213": "0.213.1",
+    "jsr:@std/encoding@0.224": "0.224.3",
+    "jsr:@std/encoding@~0.224.1": "0.224.3",
+    "jsr:@std/fs@~0.229.1": "0.229.1",
+    "jsr:@std/internal@1": "1.0.0",
+    "jsr:@std/io@0.224": "0.224.0",
+    "jsr:@std/json@~0.213.1": "0.213.1",
+    "jsr:@std/jsonc@0.213": "0.213.1",
+    "jsr:@std/path@0.213": "0.213.1",
+    "jsr:@std/path@~0.225.1": "0.225.2",
+    "jsr:@std/streams@0.224": "0.224.3",
+    "npm:@noble/curves@*": "1.4.0",
+    "npm:esbuild@*": "0.21.5",
+    "npm:esbuild@~0.21.3": "0.21.5"
+  },
+  "jsr": {
+    "@derzade/typescript-event-target@1.1.1": {
+      "integrity": "853c4cb91c333923534faf02fe68f2a91050dc41732a6899fb67ccee204f7dc7"
     },
-    "jsr": {
-      "@earthstar/willow-utils@2.0.0": {
-        "integrity": "439dda5ff8475db1093de7d59cac2b7b763571d291c72a4ac2731a4a5c835525",
-        "dependencies": [
-          "jsr:@std/bytes@^0.224.0"
-        ]
-      },
-      "@korkje/fifo@0.2.4": {
-        "integrity": "cd8ff3edf686dcfd0b26d4774705d6a080312afb666d93f3a90d3fc808df41ba"
-      },
-      "@std/assert@0.224.0": {
-        "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f"
-      },
-      "@std/assert@0.225.3": {
-        "integrity": "b3c2847aecf6955b50644cdb9cf072004ea3d1998dd7579fc0acb99dbb23bd4f",
-        "dependencies": [
-          "jsr:@std/internal@^1.0.0"
-        ]
-      },
-      "@std/assert@0.226.0": {
-        "integrity": "0dfb5f7c7723c18cec118e080fec76ce15b4c31154b15ad2bd74822603ef75b3"
-      },
-      "@std/async@0.224.1": {
-        "integrity": "2fda2c8151cc5811a6ca37fe825f1f71c95e02a374abb6ef868e0e19eca814a5",
-        "dependencies": [
-          "jsr:@std/assert@^0.225.3"
-        ]
-      },
-      "@std/bytes@0.224.0": {
-        "integrity": "a2250e1d0eb7d1c5a426f21267ab9bdeac2447fa87a3d0d1a467d3f7a6058e49"
-      },
-      "@std/bytes@1.0.0-rc.3": {
-        "integrity": "b3e93f73f1ccf167124f695596d2d026b0030930c38bd0ddec81d7f75ab41948"
-      },
-      "@std/collections@0.224.2": {
-        "integrity": "e77819455294e92d4e7ddad1dbfd46f94174c09318e541e6621fac4a4d0ab326"
-      },
-      "@std/crypto@0.224.0": {
-        "integrity": "154ef3ff08ef535562ef1a718718c5b2c5fc3808f0f9100daad69e829bfcdf2d",
-        "dependencies": [
-          "jsr:@std/assert@^0.224.0",
-          "jsr:@std/encoding@^0.224.0"
-        ]
-      },
-      "@std/data-structures@0.224.1": {
-        "integrity": "266365f90014e5c52bccf1eadd65f7782a2af2c84e4052ef8316698a3572cac3"
-      },
-      "@std/encoding@0.224.3": {
-        "integrity": "5e861b6d81be5359fad4155e591acf17c0207b595112d1840998bb9f476dbdaf"
-      },
-      "@std/fs@0.229.1": {
-        "integrity": "38d3fb31f0ca0a8c1118e039939188f32e291a3f7f17dc0868fec22024bdfadd",
-        "dependencies": [
-          "jsr:@std/assert@^0.225.2",
-          "jsr:@std/path@^0.225.1"
-        ]
-      },
-      "@std/internal@1.0.0": {
-        "integrity": "ac6a6dfebf838582c4b4f61a6907374e27e05bedb6ce276e0f1608fe84e7cd9a"
-      },
-      "@std/io@0.224.0": {
-        "integrity": "0aff885d21d829c050b8a08b1d71b54aed5841aecf227f8d77e99ec529a11e8e",
-        "dependencies": [
-          "jsr:@std/assert@^0.224.0",
-          "jsr:@std/bytes@^0.224.0"
-        ]
-      },
-      "@std/path@0.225.2": {
-        "integrity": "0f2db41d36b50ef048dcb0399aac720a5348638dd3cb5bf80685bf2a745aa506",
-        "dependencies": [
-          "jsr:@std/assert@^0.226.0"
-        ]
-      },
-      "@std/streams@0.224.3": {
-        "integrity": "38755b17defdb8a7f617acb7242ea029ac83a5deeb289b5820a3650cb031e2f6",
-        "dependencies": [
-          "jsr:@std/assert@^0.226.0",
-          "jsr:@std/bytes@^1.0.0-rc.3",
-          "jsr:@std/io@^0.224.0"
-        ]
-      }
+    "@earthstar/willow-utils@2.0.0": {
+      "integrity": "439dda5ff8475db1093de7d59cac2b7b763571d291c72a4ac2731a4a5c835525",
+      "dependencies": [
+        "jsr:@std/bytes@0.224"
+      ]
     },
-    "npm": {
-      "@noble/curves@1.4.0": {
-        "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
-        "dependencies": {
-          "@noble/hashes": "@noble/hashes@1.4.0"
-        }
-      },
-      "@noble/hashes@1.4.0": {
-        "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-        "dependencies": {}
-      }
+    "@korkje/fifo@0.2.4": {
+      "integrity": "cd8ff3edf686dcfd0b26d4774705d6a080312afb666d93f3a90d3fc808df41ba"
+    },
+    "@luca/esbuild-deno-loader@0.10.3": {
+      "integrity": "32fc93f7e7f78060234fd5929a740668aab1c742b808c6048b57f9aaea514921",
+      "dependencies": [
+        "jsr:@std/encoding@0.213",
+        "jsr:@std/jsonc",
+        "jsr:@std/path@0.213"
+      ]
+    },
+    "@std/assert@0.213.1": {
+      "integrity": "24c28178b30c8e0782c18e8e94ea72b16282207569cdd10ffb9d1d26f2edebfe"
+    },
+    "@std/assert@0.224.0": {
+      "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f"
+    },
+    "@std/assert@0.225.3": {
+      "integrity": "b3c2847aecf6955b50644cdb9cf072004ea3d1998dd7579fc0acb99dbb23bd4f",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/assert@0.226.0": {
+      "integrity": "0dfb5f7c7723c18cec118e080fec76ce15b4c31154b15ad2bd74822603ef75b3"
+    },
+    "@std/async@0.224.1": {
+      "integrity": "2fda2c8151cc5811a6ca37fe825f1f71c95e02a374abb6ef868e0e19eca814a5",
+      "dependencies": [
+        "jsr:@std/assert@~0.225.3"
+      ]
+    },
+    "@std/bytes@0.224.0": {
+      "integrity": "a2250e1d0eb7d1c5a426f21267ab9bdeac2447fa87a3d0d1a467d3f7a6058e49"
+    },
+    "@std/bytes@1.0.0-rc.3": {
+      "integrity": "b3e93f73f1ccf167124f695596d2d026b0030930c38bd0ddec81d7f75ab41948"
+    },
+    "@std/collections@0.224.2": {
+      "integrity": "e77819455294e92d4e7ddad1dbfd46f94174c09318e541e6621fac4a4d0ab326"
+    },
+    "@std/crypto@0.224.0": {
+      "integrity": "154ef3ff08ef535562ef1a718718c5b2c5fc3808f0f9100daad69e829bfcdf2d",
+      "dependencies": [
+        "jsr:@std/assert@0.224",
+        "jsr:@std/encoding@0.224"
+      ]
+    },
+    "@std/data-structures@0.224.1": {
+      "integrity": "266365f90014e5c52bccf1eadd65f7782a2af2c84e4052ef8316698a3572cac3"
+    },
+    "@std/encoding@0.213.1": {
+      "integrity": "fcbb6928713dde941a18ca5db88ca1544d0755ec8fb20fe61e2dc8144b390c62"
+    },
+    "@std/encoding@0.224.3": {
+      "integrity": "5e861b6d81be5359fad4155e591acf17c0207b595112d1840998bb9f476dbdaf"
+    },
+    "@std/fs@0.229.1": {
+      "integrity": "38d3fb31f0ca0a8c1118e039939188f32e291a3f7f17dc0868fec22024bdfadd",
+      "dependencies": [
+        "jsr:@std/assert@~0.225.2",
+        "jsr:@std/path@~0.225.1"
+      ]
+    },
+    "@std/internal@1.0.0": {
+      "integrity": "ac6a6dfebf838582c4b4f61a6907374e27e05bedb6ce276e0f1608fe84e7cd9a"
+    },
+    "@std/io@0.224.0": {
+      "integrity": "0aff885d21d829c050b8a08b1d71b54aed5841aecf227f8d77e99ec529a11e8e",
+      "dependencies": [
+        "jsr:@std/assert@0.224",
+        "jsr:@std/bytes@0.224"
+      ]
+    },
+    "@std/json@0.213.1": {
+      "integrity": "f572b1de605d07c4a5602445dac54bfc51b1fb87a3710a17aed2608bfca54e68"
+    },
+    "@std/jsonc@0.213.1": {
+      "integrity": "5578f21aa583b7eb7317eed077ffcde47b294f1056bdbb9aacec407758637bfe",
+      "dependencies": [
+        "jsr:@std/assert@~0.213.1",
+        "jsr:@std/json"
+      ]
+    },
+    "@std/path@0.213.1": {
+      "integrity": "f187bf278a172752e02fcbacf6bd78a335ed320d080a7ed3a5a59c3e88abc673",
+      "dependencies": [
+        "jsr:@std/assert@~0.213.1"
+      ]
+    },
+    "@std/path@0.225.2": {
+      "integrity": "0f2db41d36b50ef048dcb0399aac720a5348638dd3cb5bf80685bf2a745aa506",
+      "dependencies": [
+        "jsr:@std/assert@0.226"
+      ]
+    },
+    "@std/streams@0.224.3": {
+      "integrity": "38755b17defdb8a7f617acb7242ea029ac83a5deeb289b5820a3650cb031e2f6",
+      "dependencies": [
+        "jsr:@std/assert@0.226",
+        "jsr:@std/bytes@^1.0.0-rc.3",
+        "jsr:@std/io"
+      ]
+    }
+  },
+  "npm": {
+    "@esbuild/aix-ppc64@0.21.5": {
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="
+    },
+    "@esbuild/android-arm64@0.21.5": {
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="
+    },
+    "@esbuild/android-arm@0.21.5": {
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="
+    },
+    "@esbuild/android-x64@0.21.5": {
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="
+    },
+    "@esbuild/darwin-arm64@0.21.5": {
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="
+    },
+    "@esbuild/darwin-x64@0.21.5": {
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="
+    },
+    "@esbuild/freebsd-arm64@0.21.5": {
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="
+    },
+    "@esbuild/freebsd-x64@0.21.5": {
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="
+    },
+    "@esbuild/linux-arm64@0.21.5": {
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="
+    },
+    "@esbuild/linux-arm@0.21.5": {
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="
+    },
+    "@esbuild/linux-ia32@0.21.5": {
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="
+    },
+    "@esbuild/linux-loong64@0.21.5": {
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="
+    },
+    "@esbuild/linux-mips64el@0.21.5": {
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="
+    },
+    "@esbuild/linux-ppc64@0.21.5": {
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="
+    },
+    "@esbuild/linux-riscv64@0.21.5": {
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="
+    },
+    "@esbuild/linux-s390x@0.21.5": {
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="
+    },
+    "@esbuild/linux-x64@0.21.5": {
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="
+    },
+    "@esbuild/netbsd-x64@0.21.5": {
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="
+    },
+    "@esbuild/openbsd-x64@0.21.5": {
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="
+    },
+    "@esbuild/sunos-x64@0.21.5": {
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="
+    },
+    "@esbuild/win32-arm64@0.21.5": {
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="
+    },
+    "@esbuild/win32-ia32@0.21.5": {
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="
+    },
+    "@esbuild/win32-x64@0.21.5": {
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="
+    },
+    "@noble/curves@1.4.0": {
+      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "dependencies": [
+        "@noble/hashes"
+      ]
+    },
+    "@noble/hashes@1.4.0": {
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
+    },
+    "esbuild@0.21.5": {
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dependencies": [
+        "@esbuild/aix-ppc64",
+        "@esbuild/android-arm",
+        "@esbuild/android-arm64",
+        "@esbuild/android-x64",
+        "@esbuild/darwin-arm64",
+        "@esbuild/darwin-x64",
+        "@esbuild/freebsd-arm64",
+        "@esbuild/freebsd-x64",
+        "@esbuild/linux-arm",
+        "@esbuild/linux-arm64",
+        "@esbuild/linux-ia32",
+        "@esbuild/linux-loong64",
+        "@esbuild/linux-mips64el",
+        "@esbuild/linux-ppc64",
+        "@esbuild/linux-riscv64",
+        "@esbuild/linux-s390x",
+        "@esbuild/linux-x64",
+        "@esbuild/netbsd-x64",
+        "@esbuild/openbsd-x64",
+        "@esbuild/sunos-x64",
+        "@esbuild/win32-arm64",
+        "@esbuild/win32-ia32",
+        "@esbuild/win32-x64"
+      ]
     }
   },
   "remote": {
@@ -176,20 +312,21 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@earthstar/willow-utils@^2.0.0",
-      "jsr:@korkje/fifo@^0.2.4",
-      "jsr:@luca/esbuild-deno-loader@^0.10.3",
-      "jsr:@std/assert@^0.225.2",
-      "jsr:@std/async@^0.224.0",
-      "jsr:@std/bytes@^0.224.0",
-      "jsr:@std/collections@^0.224.2",
-      "jsr:@std/crypto@^0.224.0",
-      "jsr:@std/data-structures@^0.224.0",
-      "jsr:@std/encoding@^0.224.1",
-      "jsr:@std/fs@^0.229.1",
-      "jsr:@std/path@^0.225.1",
-      "jsr:@std/streams@^0.224.0",
-      "npm:esbuild@^0.21.3"
+      "jsr:@derzade/typescript-event-target@^1.1.1",
+      "jsr:@earthstar/willow-utils@2",
+      "jsr:@korkje/fifo@~0.2.4",
+      "jsr:@luca/esbuild-deno-loader@~0.10.3",
+      "jsr:@std/assert@~0.225.2",
+      "jsr:@std/async@0.224",
+      "jsr:@std/bytes@0.224",
+      "jsr:@std/collections@~0.224.2",
+      "jsr:@std/crypto@0.224",
+      "jsr:@std/data-structures@0.224",
+      "jsr:@std/encoding@~0.224.1",
+      "jsr:@std/fs@~0.229.1",
+      "jsr:@std/path@~0.225.1",
+      "jsr:@std/streams@0.224",
+      "npm:esbuild@~0.21.3"
     ]
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,257 +1,123 @@
 {
-  "version": "4",
-  "specifiers": {
-    "jsr:@derzade/typescript-event-target@^1.1.1": "1.1.1",
-    "jsr:@earthstar/willow-utils@2": "2.0.0",
-    "jsr:@korkje/fifo@~0.2.4": "0.2.4",
-    "jsr:@luca/esbuild-deno-loader@~0.10.3": "0.10.3",
-    "jsr:@std/assert@0.224": "0.224.0",
-    "jsr:@std/assert@0.226": "0.226.0",
-    "jsr:@std/assert@~0.213.1": "0.213.1",
-    "jsr:@std/assert@~0.225.2": "0.225.3",
-    "jsr:@std/assert@~0.225.3": "0.225.3",
-    "jsr:@std/async@0.224": "0.224.1",
-    "jsr:@std/bytes@0.224": "0.224.0",
-    "jsr:@std/bytes@^1.0.0-rc.3": "1.0.0-rc.3",
-    "jsr:@std/collections@~0.224.2": "0.224.2",
-    "jsr:@std/crypto@0.224": "0.224.0",
-    "jsr:@std/data-structures@0.224": "0.224.1",
-    "jsr:@std/encoding@0.213": "0.213.1",
-    "jsr:@std/encoding@0.224": "0.224.3",
-    "jsr:@std/encoding@~0.224.1": "0.224.3",
-    "jsr:@std/fs@~0.229.1": "0.229.1",
-    "jsr:@std/internal@1": "1.0.0",
-    "jsr:@std/io@0.224": "0.224.0",
-    "jsr:@std/json@~0.213.1": "0.213.1",
-    "jsr:@std/jsonc@0.213": "0.213.1",
-    "jsr:@std/path@0.213": "0.213.1",
-    "jsr:@std/path@~0.225.1": "0.225.2",
-    "jsr:@std/streams@0.224": "0.224.3",
-    "npm:@noble/curves@*": "1.4.0",
-    "npm:esbuild@*": "0.21.5",
-    "npm:esbuild@~0.21.3": "0.21.5"
-  },
-  "jsr": {
-    "@derzade/typescript-event-target@1.1.1": {
-      "integrity": "853c4cb91c333923534faf02fe68f2a91050dc41732a6899fb67ccee204f7dc7"
+  "version": "3",
+  "packages": {
+    "specifiers": {
+      "jsr:@derzade/typescript-event-target@^1.1.1": "jsr:@derzade/typescript-event-target@1.1.1",
+      "jsr:@earthstar/willow-utils@^2.0.0": "jsr:@earthstar/willow-utils@2.0.1",
+      "jsr:@korkje/fifo@^0.2.4": "jsr:@korkje/fifo@0.2.4",
+      "jsr:@std/assert@^0.224.0": "jsr:@std/assert@0.224.0",
+      "jsr:@std/assert@^0.225.2": "jsr:@std/assert@0.225.3",
+      "jsr:@std/assert@^0.226.0": "jsr:@std/assert@0.226.0",
+      "jsr:@std/async@^0.224.0": "jsr:@std/async@0.224.2",
+      "jsr:@std/bytes@^0.224.0": "jsr:@std/bytes@0.224.0",
+      "jsr:@std/bytes@^1.0.0-rc.3": "jsr:@std/bytes@1.0.5",
+      "jsr:@std/bytes@^1.0.2": "jsr:@std/bytes@1.0.5",
+      "jsr:@std/collections@^0.224.2": "jsr:@std/collections@0.224.2",
+      "jsr:@std/crypto@^0.224.0": "jsr:@std/crypto@0.224.0",
+      "jsr:@std/data-structures@^0.224.0": "jsr:@std/data-structures@0.224.1",
+      "jsr:@std/encoding@^0.224.0": "jsr:@std/encoding@0.224.3",
+      "jsr:@std/encoding@^0.224.1": "jsr:@std/encoding@0.224.3",
+      "jsr:@std/fs@^0.229.1": "jsr:@std/fs@0.229.3",
+      "jsr:@std/internal@^1.0.0": "jsr:@std/internal@1.0.5",
+      "jsr:@std/io@^0.224.1": "jsr:@std/io@0.224.9",
+      "jsr:@std/path@1.0.0-rc.1": "jsr:@std/path@1.0.0-rc.1",
+      "jsr:@std/path@^0.225.1": "jsr:@std/path@0.225.2",
+      "jsr:@std/streams@^0.224.0": "jsr:@std/streams@0.224.5",
+      "npm:@noble/curves": "npm:@noble/curves@1.4.0"
     },
-    "@earthstar/willow-utils@2.0.0": {
-      "integrity": "439dda5ff8475db1093de7d59cac2b7b763571d291c72a4ac2731a4a5c835525",
-      "dependencies": [
-        "jsr:@std/bytes@0.224"
-      ]
+    "jsr": {
+      "@derzade/typescript-event-target@1.1.1": {
+        "integrity": "853c4cb91c333923534faf02fe68f2a91050dc41732a6899fb67ccee204f7dc7"
+      },
+      "@earthstar/willow-utils@2.0.1": {
+        "integrity": "7d426c47ec8101f6f6786efd69b8ab4a1fc877514d3d0a00cbfdf6384a4c6248",
+        "dependencies": [
+          "jsr:@std/bytes@^0.224.0"
+        ]
+      },
+      "@korkje/fifo@0.2.4": {
+        "integrity": "cd8ff3edf686dcfd0b26d4774705d6a080312afb666d93f3a90d3fc808df41ba"
+      },
+      "@std/assert@0.224.0": {
+        "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f"
+      },
+      "@std/assert@0.225.3": {
+        "integrity": "b3c2847aecf6955b50644cdb9cf072004ea3d1998dd7579fc0acb99dbb23bd4f",
+        "dependencies": [
+          "jsr:@std/internal@^1.0.0"
+        ]
+      },
+      "@std/assert@0.226.0": {
+        "integrity": "0dfb5f7c7723c18cec118e080fec76ce15b4c31154b15ad2bd74822603ef75b3"
+      },
+      "@std/async@0.224.2": {
+        "integrity": "4d277d6e165df43d5e061ba0ef3edfddb8e8d558f5b920e3e6b1d2614b44d074"
+      },
+      "@std/bytes@0.224.0": {
+        "integrity": "a2250e1d0eb7d1c5a426f21267ab9bdeac2447fa87a3d0d1a467d3f7a6058e49"
+      },
+      "@std/bytes@1.0.5": {
+        "integrity": "4465dd739d7963d964c809202ebea6d5c6b8e3829ef25c6a224290fbb8a1021e"
+      },
+      "@std/collections@0.224.2": {
+        "integrity": "e77819455294e92d4e7ddad1dbfd46f94174c09318e541e6621fac4a4d0ab326"
+      },
+      "@std/crypto@0.224.0": {
+        "integrity": "154ef3ff08ef535562ef1a718718c5b2c5fc3808f0f9100daad69e829bfcdf2d",
+        "dependencies": [
+          "jsr:@std/assert@^0.224.0",
+          "jsr:@std/encoding@^0.224.0"
+        ]
+      },
+      "@std/data-structures@0.224.1": {
+        "integrity": "266365f90014e5c52bccf1eadd65f7782a2af2c84e4052ef8316698a3572cac3"
+      },
+      "@std/encoding@0.224.3": {
+        "integrity": "5e861b6d81be5359fad4155e591acf17c0207b595112d1840998bb9f476dbdaf"
+      },
+      "@std/fs@0.229.3": {
+        "integrity": "783bca21f24da92e04c3893c9e79653227ab016c48e96b3078377ebd5222e6eb",
+        "dependencies": [
+          "jsr:@std/path@1.0.0-rc.1"
+        ]
+      },
+      "@std/internal@1.0.5": {
+        "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+      },
+      "@std/io@0.224.9": {
+        "integrity": "4414664b6926f665102e73c969cfda06d2c4c59bd5d0c603fd4f1b1c840d6ee3",
+        "dependencies": [
+          "jsr:@std/bytes@^1.0.2"
+        ]
+      },
+      "@std/path@0.225.2": {
+        "integrity": "0f2db41d36b50ef048dcb0399aac720a5348638dd3cb5bf80685bf2a745aa506",
+        "dependencies": [
+          "jsr:@std/assert@^0.226.0"
+        ]
+      },
+      "@std/path@1.0.0-rc.1": {
+        "integrity": "b8c00ae2f19106a6bb7cbf1ab9be52aa70de1605daeb2dbdc4f87a7cbaf10ff6"
+      },
+      "@std/streams@0.224.5": {
+        "integrity": "bcde7818dd5460d474cdbd674b15f6638b9cd73cd64e52bd852fba2bd4d8ec91",
+        "dependencies": [
+          "jsr:@std/bytes@^1.0.0-rc.3",
+          "jsr:@std/io@^0.224.1"
+        ]
+      }
     },
-    "@korkje/fifo@0.2.4": {
-      "integrity": "cd8ff3edf686dcfd0b26d4774705d6a080312afb666d93f3a90d3fc808df41ba"
-    },
-    "@luca/esbuild-deno-loader@0.10.3": {
-      "integrity": "32fc93f7e7f78060234fd5929a740668aab1c742b808c6048b57f9aaea514921",
-      "dependencies": [
-        "jsr:@std/encoding@0.213",
-        "jsr:@std/jsonc",
-        "jsr:@std/path@0.213"
-      ]
-    },
-    "@std/assert@0.213.1": {
-      "integrity": "24c28178b30c8e0782c18e8e94ea72b16282207569cdd10ffb9d1d26f2edebfe"
-    },
-    "@std/assert@0.224.0": {
-      "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f"
-    },
-    "@std/assert@0.225.3": {
-      "integrity": "b3c2847aecf6955b50644cdb9cf072004ea3d1998dd7579fc0acb99dbb23bd4f",
-      "dependencies": [
-        "jsr:@std/internal"
-      ]
-    },
-    "@std/assert@0.226.0": {
-      "integrity": "0dfb5f7c7723c18cec118e080fec76ce15b4c31154b15ad2bd74822603ef75b3"
-    },
-    "@std/async@0.224.1": {
-      "integrity": "2fda2c8151cc5811a6ca37fe825f1f71c95e02a374abb6ef868e0e19eca814a5",
-      "dependencies": [
-        "jsr:@std/assert@~0.225.3"
-      ]
-    },
-    "@std/bytes@0.224.0": {
-      "integrity": "a2250e1d0eb7d1c5a426f21267ab9bdeac2447fa87a3d0d1a467d3f7a6058e49"
-    },
-    "@std/bytes@1.0.0-rc.3": {
-      "integrity": "b3e93f73f1ccf167124f695596d2d026b0030930c38bd0ddec81d7f75ab41948"
-    },
-    "@std/collections@0.224.2": {
-      "integrity": "e77819455294e92d4e7ddad1dbfd46f94174c09318e541e6621fac4a4d0ab326"
-    },
-    "@std/crypto@0.224.0": {
-      "integrity": "154ef3ff08ef535562ef1a718718c5b2c5fc3808f0f9100daad69e829bfcdf2d",
-      "dependencies": [
-        "jsr:@std/assert@0.224",
-        "jsr:@std/encoding@0.224"
-      ]
-    },
-    "@std/data-structures@0.224.1": {
-      "integrity": "266365f90014e5c52bccf1eadd65f7782a2af2c84e4052ef8316698a3572cac3"
-    },
-    "@std/encoding@0.213.1": {
-      "integrity": "fcbb6928713dde941a18ca5db88ca1544d0755ec8fb20fe61e2dc8144b390c62"
-    },
-    "@std/encoding@0.224.3": {
-      "integrity": "5e861b6d81be5359fad4155e591acf17c0207b595112d1840998bb9f476dbdaf"
-    },
-    "@std/fs@0.229.1": {
-      "integrity": "38d3fb31f0ca0a8c1118e039939188f32e291a3f7f17dc0868fec22024bdfadd",
-      "dependencies": [
-        "jsr:@std/assert@~0.225.2",
-        "jsr:@std/path@~0.225.1"
-      ]
-    },
-    "@std/internal@1.0.0": {
-      "integrity": "ac6a6dfebf838582c4b4f61a6907374e27e05bedb6ce276e0f1608fe84e7cd9a"
-    },
-    "@std/io@0.224.0": {
-      "integrity": "0aff885d21d829c050b8a08b1d71b54aed5841aecf227f8d77e99ec529a11e8e",
-      "dependencies": [
-        "jsr:@std/assert@0.224",
-        "jsr:@std/bytes@0.224"
-      ]
-    },
-    "@std/json@0.213.1": {
-      "integrity": "f572b1de605d07c4a5602445dac54bfc51b1fb87a3710a17aed2608bfca54e68"
-    },
-    "@std/jsonc@0.213.1": {
-      "integrity": "5578f21aa583b7eb7317eed077ffcde47b294f1056bdbb9aacec407758637bfe",
-      "dependencies": [
-        "jsr:@std/assert@~0.213.1",
-        "jsr:@std/json"
-      ]
-    },
-    "@std/path@0.213.1": {
-      "integrity": "f187bf278a172752e02fcbacf6bd78a335ed320d080a7ed3a5a59c3e88abc673",
-      "dependencies": [
-        "jsr:@std/assert@~0.213.1"
-      ]
-    },
-    "@std/path@0.225.2": {
-      "integrity": "0f2db41d36b50ef048dcb0399aac720a5348638dd3cb5bf80685bf2a745aa506",
-      "dependencies": [
-        "jsr:@std/assert@0.226"
-      ]
-    },
-    "@std/streams@0.224.3": {
-      "integrity": "38755b17defdb8a7f617acb7242ea029ac83a5deeb289b5820a3650cb031e2f6",
-      "dependencies": [
-        "jsr:@std/assert@0.226",
-        "jsr:@std/bytes@^1.0.0-rc.3",
-        "jsr:@std/io"
-      ]
-    }
-  },
-  "npm": {
-    "@esbuild/aix-ppc64@0.21.5": {
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="
-    },
-    "@esbuild/android-arm64@0.21.5": {
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="
-    },
-    "@esbuild/android-arm@0.21.5": {
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="
-    },
-    "@esbuild/android-x64@0.21.5": {
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="
-    },
-    "@esbuild/darwin-arm64@0.21.5": {
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="
-    },
-    "@esbuild/darwin-x64@0.21.5": {
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="
-    },
-    "@esbuild/freebsd-arm64@0.21.5": {
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="
-    },
-    "@esbuild/freebsd-x64@0.21.5": {
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="
-    },
-    "@esbuild/linux-arm64@0.21.5": {
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="
-    },
-    "@esbuild/linux-arm@0.21.5": {
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="
-    },
-    "@esbuild/linux-ia32@0.21.5": {
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="
-    },
-    "@esbuild/linux-loong64@0.21.5": {
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="
-    },
-    "@esbuild/linux-mips64el@0.21.5": {
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="
-    },
-    "@esbuild/linux-ppc64@0.21.5": {
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="
-    },
-    "@esbuild/linux-riscv64@0.21.5": {
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="
-    },
-    "@esbuild/linux-s390x@0.21.5": {
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="
-    },
-    "@esbuild/linux-x64@0.21.5": {
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="
-    },
-    "@esbuild/netbsd-x64@0.21.5": {
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="
-    },
-    "@esbuild/openbsd-x64@0.21.5": {
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="
-    },
-    "@esbuild/sunos-x64@0.21.5": {
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="
-    },
-    "@esbuild/win32-arm64@0.21.5": {
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="
-    },
-    "@esbuild/win32-ia32@0.21.5": {
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="
-    },
-    "@esbuild/win32-x64@0.21.5": {
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="
-    },
-    "@noble/curves@1.4.0": {
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
-      "dependencies": [
-        "@noble/hashes"
-      ]
-    },
-    "@noble/hashes@1.4.0": {
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
-    },
-    "esbuild@0.21.5": {
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dependencies": [
-        "@esbuild/aix-ppc64",
-        "@esbuild/android-arm",
-        "@esbuild/android-arm64",
-        "@esbuild/android-x64",
-        "@esbuild/darwin-arm64",
-        "@esbuild/darwin-x64",
-        "@esbuild/freebsd-arm64",
-        "@esbuild/freebsd-x64",
-        "@esbuild/linux-arm",
-        "@esbuild/linux-arm64",
-        "@esbuild/linux-ia32",
-        "@esbuild/linux-loong64",
-        "@esbuild/linux-mips64el",
-        "@esbuild/linux-ppc64",
-        "@esbuild/linux-riscv64",
-        "@esbuild/linux-s390x",
-        "@esbuild/linux-x64",
-        "@esbuild/netbsd-x64",
-        "@esbuild/openbsd-x64",
-        "@esbuild/sunos-x64",
-        "@esbuild/win32-arm64",
-        "@esbuild/win32-ia32",
-        "@esbuild/win32-x64"
-      ]
+    "npm": {
+      "@noble/curves@1.4.0": {
+        "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+        "dependencies": {
+          "@noble/hashes": "@noble/hashes@1.4.0"
+        }
+      },
+      "@noble/hashes@1.4.0": {
+        "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+        "dependencies": {}
+      }
     }
   },
   "remote": {
@@ -313,20 +179,20 @@
   "workspace": {
     "dependencies": [
       "jsr:@derzade/typescript-event-target@^1.1.1",
-      "jsr:@earthstar/willow-utils@2",
-      "jsr:@korkje/fifo@~0.2.4",
-      "jsr:@luca/esbuild-deno-loader@~0.10.3",
-      "jsr:@std/assert@~0.225.2",
-      "jsr:@std/async@0.224",
-      "jsr:@std/bytes@0.224",
-      "jsr:@std/collections@~0.224.2",
-      "jsr:@std/crypto@0.224",
-      "jsr:@std/data-structures@0.224",
-      "jsr:@std/encoding@~0.224.1",
-      "jsr:@std/fs@~0.229.1",
-      "jsr:@std/path@~0.225.1",
-      "jsr:@std/streams@0.224",
-      "npm:esbuild@~0.21.3"
+      "jsr:@earthstar/willow-utils@^2.0.0",
+      "jsr:@korkje/fifo@^0.2.4",
+      "jsr:@luca/esbuild-deno-loader@^0.10.3",
+      "jsr:@std/assert@^0.225.2",
+      "jsr:@std/async@^0.224.0",
+      "jsr:@std/bytes@^0.224.0",
+      "jsr:@std/collections@^0.224.2",
+      "jsr:@std/crypto@^0.224.0",
+      "jsr:@std/data-structures@^0.224.0",
+      "jsr:@std/encoding@^0.224.1",
+      "jsr:@std/fs@^0.229.1",
+      "jsr:@std/path@^0.225.1",
+      "jsr:@std/streams@^0.224.0",
+      "npm:esbuild@^0.21.3"
     ]
   }
 }

--- a/src/store/events.ts
+++ b/src/store/events.ts
@@ -1,6 +1,52 @@
 import type { Entry } from "@earthstar/willow-utils";
 import type { Payload } from "./types.ts";
 
+export enum StoreEvents {
+  EntryIngest = "entryingest",
+  EntryPayloadSet = "entrypayloadset",
+  EntryRemove = "entryremove",
+  PayloadIngest = "payloadingest",
+  PayloadRemove = "payloadRemove",
+}
+
+export type StoreEventsMapping<
+  NamespacePublicKey,
+  SubspacePublicKey,
+  PayloadDigest,
+  AuthorisationToken,
+> = {
+  [StoreEvents.EntryPayloadSet]: EntryPayloadSetEvent<
+    NamespacePublicKey,
+    SubspacePublicKey,
+    PayloadDigest,
+    AuthorisationToken
+  >;
+  [StoreEvents.EntryIngest]: EntryIngestEvent<
+    NamespacePublicKey,
+    SubspacePublicKey,
+    PayloadDigest,
+    AuthorisationToken
+  >;
+  [StoreEvents.PayloadIngest]: PayloadIngestEvent<
+    NamespacePublicKey,
+    SubspacePublicKey,
+    PayloadDigest,
+    AuthorisationToken
+  >;
+  [StoreEvents.EntryRemove]: EntryRemoveEvent<
+    NamespacePublicKey,
+    SubspacePublicKey,
+    PayloadDigest,
+    AuthorisationToken
+  >;
+  [StoreEvents.PayloadRemove]: PayloadRemoveEvent<
+    NamespacePublicKey,
+    SubspacePublicKey,
+    PayloadDigest,
+    AuthorisationToken
+  >;
+};
+
 export class EntryPayloadSetEvent<
   NamespacePublicKey,
   SubspacePublicKey,
@@ -16,7 +62,7 @@ export class EntryPayloadSetEvent<
     authToken: AuthorisationToken,
     payload: Payload,
   ) {
-    super("entrypayloadset", {
+    super(StoreEvents.EntryPayloadSet, {
       detail: {
         entry,
         authToken,
@@ -42,7 +88,7 @@ export class EntryIngestEvent<
     entry: Entry<NamespacePublicKey, SubspacePublicKey, PayloadDigest>,
     authToken: AuthorisationToken,
   ) {
-    super("entryingest", {
+    super(StoreEvents.EntryIngest, {
       detail: {
         entry,
         authToken,
@@ -67,7 +113,7 @@ export class PayloadIngestEvent<
     authToken: AuthorisationToken,
     payload: Payload,
   ) {
-    super("payloadingest", {
+    super(StoreEvents.PayloadIngest, {
       detail: {
         entry,
         authToken,
@@ -99,7 +145,7 @@ export class EntryRemoveEvent<
       authToken: AuthorisationToken;
     },
   ) {
-    super("entryremove", {
+    super(StoreEvents.EntryRemove, {
       detail: {
         removed,
         removedBy,
@@ -128,7 +174,7 @@ export class PayloadRemoveEvent<
       authToken: AuthorisationToken;
     },
   ) {
-    super("payloadRemove", {
+    super(StoreEvents.PayloadRemove, {
       detail: {
         removedBy,
       },

--- a/src/store/events.ts
+++ b/src/store/events.ts
@@ -1,13 +1,13 @@
 import type { Entry } from "@earthstar/willow-utils";
 import type { Payload } from "./types.ts";
 
-export enum StoreEvents {
-  EntryIngest = "entryingest",
-  EntryPayloadSet = "entrypayloadset",
-  EntryRemove = "entryremove",
-  PayloadIngest = "payloadingest",
-  PayloadRemove = "payloadRemove",
-}
+export const StoreEvents = {
+  EntryIngest: "entryingest",
+  EntryPayloadSet: "entrypayloadset",
+  EntryRemove: "entryremove",
+  PayloadIngest: "payloadingest",
+  PayloadRemove: "payloadRemove",
+} as const
 
 export type StoreEventsMapping<
   NamespacePublicKey,

--- a/src/store/events.ts
+++ b/src/store/events.ts
@@ -9,7 +9,7 @@ export const StoreEvents = {
   PayloadRemove: "payloadremove",
 } as const;
 
-export type StoreEventsMapping<
+export type StoreEventsMap<
   NamespacePublicKey,
   SubspacePublicKey,
   PayloadDigest,

--- a/src/store/events.ts
+++ b/src/store/events.ts
@@ -6,7 +6,7 @@ export const StoreEvents = {
   EntryPayloadSet: "entrypayloadset",
   EntryRemove: "entryremove",
   PayloadIngest: "payloadingest",
-  PayloadRemove: "payloadRemove",
+  PayloadRemove: "payloadremove",
 } as const
 
 export type StoreEventsMapping<
@@ -47,6 +47,7 @@ export type StoreEventsMapping<
   >;
 };
 
+/** Emitted after a {@linkcode Store} creates a new {@linkcode Entry} for a given payload. */
 export class EntryPayloadSetEvent<
   NamespacePublicKey,
   SubspacePublicKey,

--- a/src/store/events.ts
+++ b/src/store/events.ts
@@ -7,7 +7,7 @@ export const StoreEvents = {
   EntryRemove: "entryremove",
   PayloadIngest: "payloadingest",
   PayloadRemove: "payloadremove",
-} as const
+} as const;
 
 export type StoreEventsMapping<
   NamespacePublicKey,

--- a/src/store/storage/storage_3d/storage_3d.test.ts
+++ b/src/store/storage/storage_3d/storage_3d.test.ts
@@ -293,14 +293,14 @@ Deno.test("Storage3d.summarise", async () => {
         return new Uint8Array(0);
       },
       decode: (_encoded: Uint8Array) => {
-        return <[number, Path, bigint, bigint][]>[];
+        return <[number, Path, bigint, bigint][]> [];
       },
       encodedLength: (_value: [number, Path, bigint, bigint][]) => {
         return 0;
       },
       decodeStream: <StreamDecoder<
         [number, Path, bigint, bigint][]
-      >><unknown>"unused",
+      >> <unknown> "unused",
     },
   };
 
@@ -736,8 +736,8 @@ Deno.test("Storage3d.query", async (test) => {
           order: orderRoll < 0.33
             ? "subspace"
             : orderRoll < 0.66
-              ? "path"
-              : "timestamp",
+            ? "path"
+            : "timestamp",
         });
       }
 
@@ -783,7 +783,7 @@ Deno.test("Storage3d.query", async (test) => {
       }
 
       store.addEventListener("entryremove", (event) => {
-        const { detail: { removed } } = event
+        const { detail: { removed } } = event;
 
         const encodedEntry = encodeEntry({
           encodeNamespace: testSchemeNamespace.encode,

--- a/src/store/storage/storage_3d/storage_3d.test.ts
+++ b/src/store/storage/storage_3d/storage_3d.test.ts
@@ -293,14 +293,14 @@ Deno.test("Storage3d.summarise", async () => {
         return new Uint8Array(0);
       },
       decode: (_encoded: Uint8Array) => {
-        return <[number, Path, bigint, bigint][]> [];
+        return <[number, Path, bigint, bigint][]>[];
       },
       encodedLength: (_value: [number, Path, bigint, bigint][]) => {
         return 0;
       },
       decodeStream: <StreamDecoder<
         [number, Path, bigint, bigint][]
-      >> <unknown> "unused",
+      >><unknown>"unused",
     },
   };
 
@@ -736,8 +736,8 @@ Deno.test("Storage3d.query", async (test) => {
           order: orderRoll < 0.33
             ? "subspace"
             : orderRoll < 0.66
-            ? "path"
-            : "timestamp",
+              ? "path"
+              : "timestamp",
         });
       }
 
@@ -783,9 +783,7 @@ Deno.test("Storage3d.query", async (test) => {
       }
 
       store.addEventListener("entryremove", (event) => {
-        const { detail: { removed } } = event as CustomEvent<
-          { removed: Entry<TestNamespace, TestSubspace, Uint8Array> }
-        >;
+        const { detail: { removed } } = event
 
         const encodedEntry = encodeEntry({
           encodeNamespace: testSchemeNamespace.encode,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -15,6 +15,8 @@ import {
   EntryRemoveEvent,
   PayloadIngestEvent,
   PayloadRemoveEvent,
+  StoreEvents,
+  type StoreEventsMapping,
 } from "./events.ts";
 import type { Storage3d } from "./storage/storage_3d/types.ts";
 import { WillowError } from "../errors.ts";
@@ -33,6 +35,7 @@ import {
   successorPath,
   successorPrefix,
 } from "@earthstar/willow-utils";
+import { TypedEventTarget } from "@derzade/typescript-event-target";
 
 /** A local set of a particular namespace's authorised entries to be written to, read from, and synced with other `Store`s. Applies the concepts of the [Willow Data Model](https://willowprotocol.org/specs/data-model/index.html#data_model) to the set of entries stored inside.
  *
@@ -48,7 +51,9 @@ export class Store<
   AuthorisationToken,
   Prefingerprint,
   Fingerprint,
-> extends EventTarget {
+> extends TypedEventTarget<
+  StoreEventsMapping<NamespaceId, SubspaceId, PayloadDigest, AuthorisationToken>
+> {
   namespace: NamespaceId;
 
   private schemes: StoreSchemes<
@@ -206,7 +211,10 @@ export class Store<
       return ingestResult;
     }
 
-    this.dispatchEvent(new EntryPayloadSetEvent(entry, authToken, payload));
+    this.dispatchTypedEvent(
+      StoreEvents.EntryPayloadSet,
+      new EntryPayloadSetEvent(entry, authToken, payload),
+    );
 
     return ingestResult;
   }
@@ -396,7 +404,8 @@ export class Store<
         toRemovePrefixPath,
       );
 
-      this.dispatchEvent(
+      this.dispatchTypedEvent(
+        StoreEvents.EntryRemove,
         new EntryRemoveEvent(otherEntry, { entry, authToken: authorisation }),
       );
     }
@@ -413,7 +422,10 @@ export class Store<
     // Indicates that this ingestion is not being triggered by a local set,
     // so the payload will arrive separately.
     if (externalSourceId) {
-      this.dispatchEvent(new EntryIngestEvent(entry, authorisation));
+      this.dispatchTypedEvent(
+        StoreEvents.EntryIngest,
+        new EntryIngestEvent(entry, authorisation),
+      );
     }
 
     this.ingestionMutex.release(acquisitionId);
@@ -570,7 +582,8 @@ export class Store<
         ),
       ]);
 
-      this.dispatchEvent(
+      this.dispatchTypedEvent(
+        StoreEvents.PayloadRemove,
         new PayloadRemoveEvent({ entry, authToken }),
       );
 
@@ -578,7 +591,8 @@ export class Store<
 
       await this.entryDriver.writeAheadFlag.unflagRemoval();
 
-      this.dispatchEvent(
+      this.dispatchTypedEvent(
+        StoreEvents.EntryRemove,
         new EntryRemoveEvent(entry, {
           entry: {
             namespaceId: this.namespace,
@@ -691,7 +705,8 @@ export class Store<
         );
       }
 
-      this.dispatchEvent(
+      this.dispatchTypedEvent(
+        StoreEvents.PayloadIngest,
         new PayloadIngestEvent(entry, authToken, complete),
       );
     }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -16,7 +16,7 @@ import {
   PayloadIngestEvent,
   PayloadRemoveEvent,
   StoreEvents,
-  type StoreEventsMapping,
+  type StoreEventsMap,
 } from "./events.ts";
 import type { Storage3d } from "./storage/storage_3d/types.ts";
 import { WillowError } from "../errors.ts";
@@ -35,7 +35,7 @@ import {
   successorPath,
   successorPrefix,
 } from "@earthstar/willow-utils";
-import { TypedEventTarget } from "@derzade/typescript-event-target";
+import { TypedEventTarget } from "jsr:@derzade/typescript-event-target";
 
 /** A local set of a particular namespace's authorised entries to be written to, read from, and synced with other `Store`s. Applies the concepts of the [Willow Data Model](https://willowprotocol.org/specs/data-model/index.html#data_model) to the set of entries stored inside.
  *
@@ -52,7 +52,7 @@ export class Store<
   Prefingerprint,
   Fingerprint,
 > extends TypedEventTarget<
-  StoreEventsMapping<NamespaceId, SubspaceId, PayloadDigest, AuthorisationToken>
+  StoreEventsMap<NamespaceId, SubspaceId, PayloadDigest, AuthorisationToken>
 > {
   namespace: NamespaceId;
 
@@ -667,10 +667,10 @@ export class Store<
       (result.length > entry.payloadLength) ||
       (allowPartial === false && entry.payloadLength !== result.length) ||
       result.length === entry.payloadLength &&
-        this.schemes.payload.order(
-            result.digest,
-            entry.payloadDigest,
-          ) !== 0
+      this.schemes.payload.order(
+        result.digest,
+        entry.payloadDigest,
+      ) !== 0
     ) {
       await result.reject();
 
@@ -685,9 +685,9 @@ export class Store<
     if (
       result.length === entry.payloadLength &&
       this.schemes.payload.order(
-          result.digest,
-          entry.payloadDigest,
-        ) === 0
+        result.digest,
+        entry.payloadDigest,
+      ) === 0
     ) {
       const complete = await this.payloadDriver.get(entry.payloadDigest);
 


### PR DESCRIPTION
While reviewing issue [#341](https://github.com/earthstar-project/earthstar/issues/341), I noticed that `EventTarget` lacks robust type safety. Using [typescript-event-target](https://jsr.io/@derzade/typescript-event-target), which just extends EventTarget with better types in 100 lines, significantly enhances type safety. I will make a pull request after this one to also incorporate it into Earthstar along with the new Auth events. 

If introducing a new dependency is a concern, we can alternatively integrate it directly into the codebase.

This enhancement will eliminate the need for forced types using `as` in [relayWillowEvents](https://github.com/earthstar-project/earthstar/blob/078646916e8cb333b22d6a3b4ccde6889282f429/src/store/events.ts#L55), thus improving developer experience without introducing any breaking changes.

![imagen](https://github.com/user-attachments/assets/4367f5b4-9c70-4c61-a768-1d8841e9581f)
![imagen](https://github.com/user-attachments/assets/fe7030e6-1181-4e5d-ae8c-090876b067cb)
